### PR TITLE
securedrop-proxy 0.1.1 and securedrop-client 0.0.2

### DIFF
--- a/securedrop-client/debian/changelog
+++ b/securedrop-client/debian/changelog
@@ -1,3 +1,14 @@
+securedrop-client (0.0.2) unstable; urgency=medium
+
+  * Enable decryption and viewing of replies (#114).
+  * Enable decryption and viewing of messages (#99).
+  * Enable decryption and opening of files in a DispVM (#113).
+  * Add status bar on bottom of application (#65).
+  * Prevent concurrent application launches (#54).
+  * Enable starring/unstarring of sources (#50).
+
+ -- redshiftzero <jen@freedom.press>  Wed, 07 Nov 2018 19:39:22 -0500
+
 securedrop-client (0.0.1) unstable; urgency=medium
 
   * Initial release.

--- a/securedrop-proxy/debian/changelog
+++ b/securedrop-proxy/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-proxy (0.1.1) unstable; urgency=medium
+
+  * Update requests to 2.20.0
+
+ -- redshiftzero <jen@freedom.press>  Wed, 07 Nov 2018 19:37:41 -0500
+
 securedrop-proxy (0.1.0) unstable; urgency=medium
 
   * Initial release. (Closes: #XXX)


### PR DESCRIPTION
This is on top of #9 and contains the changelog updates for `securedrop-proxy 0.1.1` and `securedrop-client 0.0.2`, I built debs and they are now on apt-test-qubes.freedom.press (thanks to @emkll for pushing the packages up) 