### PR TITLE
Resolves venv paths in python deb packages

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -60,16 +60,16 @@ dch --newversion "${PKG_VERSION}" --distribution unstable -c "${CUR_DIR}/${PKG_N
 cp "$PKG_PATH" "$TOP_BUILDDIR/$PKG_NAME/"
 
 # Extract the source tarball in the packaging workspace
-tar -C "$TOP_BUILDDIR/$PKG_NAME" -xvf "$PKG_PATH"
+tar --strip-components=1 -C "$TOP_BUILDDIR/$PKG_NAME" -xvf "$PKG_PATH"
 
 # Copy over the debian directory (including new changelog) from repo
-cp -r "$CUR_DIR/$PKG_NAME/debian" "$TOP_BUILDDIR/$PKG_NAME/$PKG_NAME-$PKG_VERSION"
+cp -r "$CUR_DIR/$PKG_NAME/debian" "$TOP_BUILDDIR/$PKG_NAME/"
 
 # Create symlink to the localwheels directory
-ln -s "$CUR_DIR/localwheels" "$TOP_BUILDDIR/$PKG_NAME/$PKG_NAME-$PKG_VERSION/localwheels"
+ln -s "$CUR_DIR/localwheels" "$TOP_BUILDDIR/$PKG_NAME/localwheels"
 
 # Hop into the package build dir, to run dpkg-buildpackage
-cd "$TOP_BUILDDIR/$PKG_NAME/$PKG_NAME-$PKG_VERSION"
+cd "$TOP_BUILDDIR/$PKG_NAME/"
 
 # Build the package
 dpkg-buildpackage -us -uc

--- a/securedrop-client/debian/changelog
+++ b/securedrop-client/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-client (0.0.2-1) unstable; urgency=medium
+
+  * Resolves venv paths in generated scripts (via dh-virtualenv)
+
+ -- Conor Schaefer <conor@freedom.press>  Thu, 08 Nov 2018 18:45:53 -0800
+
 securedrop-client (0.0.2) unstable; urgency=medium
 
   * Enable decryption and viewing of replies (#114).

--- a/securedrop-proxy/debian/changelog
+++ b/securedrop-proxy/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-proxy (0.1.1-1) unstable; urgency=medium
+
+  * Resolves venv paths in generated scripts (via dh-virtualenv)
+
+ -- Conor Schaefer <conor@freedom.press>  Thu, 08 Nov 2018 18:51:12 -0800
+
 securedrop-proxy (0.1.1) unstable; urgency=medium
 
   * Update requests to 2.20.0


### PR DESCRIPTION
The new build logic that came in via #9 introduced a regression, where
the venv path inside the scripts packaged in the debs was
inappropriately using a fullpath from the build environment.

Modifying the pardir to match the package name exactly resolved; it was
necessary to tweak the tar command to make sure the files land adjacent
to the debian dir as the build tooling expects.

Closes #12.