### PR TITLE
Add .desktop file shortcut for securedrop-client

### DIFF
--- a/securedrop-client/debian/changelog
+++ b/securedrop-client/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-client (0.0.4) unstable; urgency=medium
+
+  * Adds .desktop shortcut.
+
+ -- mickael e. <mickael@freedom.press>  Fri, 09 Nov 2018 16:18:55 -0500
+
 securedrop-client (0.0.3) unstable; urgency=medium
 
   * Fix and squash migrations (#129).

--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -5,3 +5,4 @@ alembic/README usr/share/securedrop-client/alembic/
 alembic/script.py.mako usr/share/securedrop-client/alembic/
 alembic/versions/5344fc3a3d3f_initial_migration.py usr/share/securedrop-client/alembic/versions/
 files/securedrop-client usr/bin/
+files/securedrop-client.desktop usr/share/applications/


### PR DESCRIPTION
Requires securedrop-client 0.0.4 code from https://github.com/freedomofpress/securedrop-client/pull/141

Towards https://github.com/freedomofpress/securedrop-workstation/issues/198 : Once this and the client PR are merged, we will need to update the application list to have only SecureDrop Client in the application menu for sd-svs.

Test plan:

```
# checkout this branch, cd ..
git clone https://github.com/freedomofpress/securedrop-client
git checkout 0.0.4
python3 setup.py sdist
# return to this repo, and build the package:
PKG_VERSION=0.0.4 make securedrop-client
```
- [ ] The resulting .deb package installs successfully in sd-svs-template
- [ ] When refreshing the application list, SecureDrop client is in the list of applications
- [ ] Clicking on this opens the SecureDrop client