### PR TITLE
Removes dch and localwheels syncing part of build steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ syncwheels: ## Downloads wheels and sources from the remote server
 	./scripts/syncwheels
 
 .PHONY: securedrop-proxy
-securedrop-proxy: syncwheels ## Builds Debian package for securedrop-proxy code
+securedrop-proxy: ## Builds Debian package for securedrop-proxy code
 	PKG_NAME="securedrop-proxy" ./scripts/build-debianpackage
 
 .PHONY: securedrop-client
-securedrop-client: syncwheels ## Builds Debian package for securedrop-client code
+securedrop-client: ## Builds Debian package for securedrop-client code
 	PKG_NAME="securedrop-client" ./scripts/build-debianpackage
 
 .PHONY: securedrop-workstation-config

--- a/README.md
+++ b/README.md
@@ -36,12 +36,24 @@ Generate a tarball to be used in the build process:
 python3 setup.py sdist
 ```
 
-Finally, build the package by cloning this repository, and pointing to the tarball and package version:
+Clone this repository for access to the packaging tooling.
 
 ```
 cd ..
 git clone git@github.com:freedomofpress/securedrop-debian-packaging.git
 cd securedrop-debian-packaging
+```
+
+If you are releasing a new version (rather than rebuilding a package from a previous version),
+you must update the changelog:
+
+```
+./scripts/update-changelog securedrop-foobar
+```
+
+Finally, build the package by pointing to the tarball and package version:
+
+```
 PKG_PATH=/path/to/tarball PKG_VERSION=0.x.y make securedrop-foobar
 ```
 

--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -51,10 +51,6 @@ mkdir -p "${TOP_BUILDDIR}/${PKG_NAME}"
 
 printf "Building package '%s' from version '%s'...\\n" "$PKG_NAME" "$PKG_VERSION"
 
-# Update changelog interactively. Currently using "unstable" but we intend
-# to target "stretch" for SDW applications. Must run before files are copied
-# into non-version-controlled build dir.
-dch --newversion "${PKG_VERSION}" --distribution unstable -c "${CUR_DIR}/${PKG_NAME}/debian/changelog"
 
 # Copy the source tarball to the packaging workspace
 cp "$PKG_PATH" "$TOP_BUILDDIR/$PKG_NAME/"
@@ -65,8 +61,6 @@ tar --strip-components=1 -C "$TOP_BUILDDIR/$PKG_NAME" -xvf "$PKG_PATH"
 # Copy over the debian directory (including new changelog) from repo
 cp -r "$CUR_DIR/$PKG_NAME/debian" "$TOP_BUILDDIR/$PKG_NAME/"
 
-# Create symlink to the localwheels directory
-ln -s "$CUR_DIR/localwheels" "$TOP_BUILDDIR/$PKG_NAME/localwheels"
 
 # Hop into the package build dir, to run dpkg-buildpackage
 cd "$TOP_BUILDDIR/$PKG_NAME/"

--- a/scripts/update-changelog
+++ b/scripts/update-changelog
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Wrapper script for `dch`, for editing changelogs in Debian packages.
+# Provides flags on invocation, and also checks for env vars, so that
+# maintainer info makes it into the package.
+set -e
+set -u
+set -o pipefail
+
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+
+# These env vars are only required when updating changelogs,
+# otherwise the developer must edit the fields by hand, lest
+# they commit "user@localhost" entries.
+if [[ -z "${DEBEMAIL:-}" || -z "${DEBFULLNAME:-}" ]]; then
+    echo "Error: cannot find env vars DEBEMAIL and DEBFULLNAME"
+    echo "Export those env vars in order to update changelogs"
+    exit 1
+fi
+
+
+# Determine which package we want to update the changelog for.
+# As with the other tools, we'll support the PKG_NAME env var.
+PKG_NAME="${PKG_NAME:-}"
+if [[ -z "${PKG_NAME:-}" ]]; then
+    if [[ -n "${1:-}" ]]; then
+        PKG_NAME="$1"
+        shift
+    else
+        printf 'Usage: %s <package_name>\n' "$0"
+        printf 'You can also export PKG_NAME\n'
+        exit 2
+    fi
+fi
+
+if [[ -z "${PKG_VERSION:-}" ]]; then
+    echo "Error: cannot find env var PKG_VERSION."
+    exit 3
+fi
+
+
+# Update the changelog.
+changelog="${TOPLEVEL}/${PKG_NAME}/debian/changelog"
+if [[ ! -f "$changelog" ]]; then
+    printf 'Could not find changelog at %s\n' "$changelog"
+    exit 4
+fi
+
+dch --newversion "${PKG_VERSION}" --distribution unstable -c "$changelog"


### PR DESCRIPTION
Fixes #19. 

### How to test?

Build of any of the existing package. Remember to update the path based on the location of the source tarball.

```
PKG_PATH=/home/user/code/securedrop-client/dist/securedrop-client-0.0.5.tar.gz PKG_VERSION=0.0.5 make securedrop-client
```