### PR TITLE
Fixes #32 brings reproducible builds back

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -45,6 +45,7 @@ fi
 # Disable use of pip cache during debhelper build actions.
 export DH_PIP_EXTRA_ARGS="--no-cache-dir --require-hashes"
 
+
 # Declare general packaging building workspace; subdirs will
 # be created within, to build specific packages.
 TOP_BUILDDIR="$HOME/debbuild/packaging"
@@ -72,6 +73,9 @@ cd "$TOP_BUILDDIR/$PKG_NAME/"
 $CUR_DIR/scripts/verify-hashes $CUR_DIR/sha256sums.txt ./requirements.txt
 
 echo "All hashes verified."
+
+# Adds reproducibility step
+export SOURCE_DATE_EPOCH=`dpkg-parsechangelog -STimestamp`
 
 # Build the package
 dpkg-buildpackage -us -uc

--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -6,4 +6,8 @@
 override_dh_virtualenv:
 	dh_virtualenv --python /usr/bin/python3.5 --setuptools -S --index-url https://dev-bin.ops.securedrop.org/simple
 
-
+override_dh_strip_nondeterminism:
+	find ./debian/ -type f -name '*.pyc' -delete
+	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
+	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
+	dh_strip_nondeterminism $@

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -2,3 +2,10 @@
 
 %:
 	dh $@ --with python-virtualenv --python /usr/bin/python3.5 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple
+
+override_dh_strip_nondeterminism:
+	find ./debian/ -type f -name '*.pyc' -delete
+	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
+	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
+	dh_strip_nondeterminism $@
+


### PR DESCRIPTION
Using these changes we can have reproducible builds, as we will be using the same source tarball and also the same wheels to build the final package.

Fixes #32.

### How to test?

Build the `securedrop-client` twice, after the first build, move the deb package to a directory called `aa` and then the second build to `bb`. After this run `diffoscope` against them.

```
mkdir aa bb
PKG_PATH=/home/user/code/securedrop-client/dist/securedrop-client-0.0.6.tar.gz PKG_VERSION=0.0.6 make securedrop-client
mv ~/debbuild/packaging/securedrop-client_0.0.6_all.deb aa/

PKG_PATH=/home/user/code/securedrop-client/dist/securedrop-client-0.0.6.tar.gz PKG_VERSION=0.0.6 make securedrop-client
mv ~/debbuild/packaging/securedrop-client_0.0.6_all.deb bb/

$ diffoscope aa/securedrop-client_0.0.6_all.deb bb/securedrop-client_0.0.6_all.deb 
|###############################################################################################################################################################|  100%                             Time: 0:00:00 
```