### PR TITLE
Updates changelog for securedrop-proxy 0.1.3

### DIFF
--- a/securedrop-proxy/debian/changelog
+++ b/securedrop-proxy/debian/changelog
@@ -1,3 +1,10 @@
+securedrop-proxy (0.1.3) UNRELEASED; urgency=medium
+
+  * Updated PyYAML to 5.1 and safe loading of YAML files
+    #24 and #25
+
+ -- Kushal Das <kushal@freedom.press>  Thu, 25 Apr 2019 02:02:38 +0530
+
 securedrop-proxy (0.1.2) unstable; urgency=medium
 
   * Update requirements: Remove dev requirements (#20), update wheel hashes


### PR DESCRIPTION
Now one can build `securedrop-proxy` `0.1.3` package.