### PR TITLE
update install file for the securedrop client

### DIFF
--- a/securedrop-client/debian/changelog
+++ b/securedrop-client/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-client (0.0.7) unstable; urgency=medium
+
+  * Update securedrop-sdk to 0.0.8 (#357)
+
+ -- Allie Crevier <allie@freedom.press>  Mon, 06 May 2019 16:01:16 -0400
+
 securedrop-client (0.0.6) unstable; urgency=medium
 
   * Long lived threads are now de-authenticated on logout (#179)

--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -2,7 +2,6 @@ files/alembic.ini usr/share/securedrop-client/
 alembic/env.py usr/share/securedrop-client/alembic/
 alembic/README usr/share/securedrop-client/alembic/
 alembic/script.py.mako usr/share/securedrop-client/alembic/
-alembic/versions/5344fc3a3d3f_initial_migration.py usr/share/securedrop-client/alembic/versions/
-alembic/versions/cd0fbb73bf8e_capture_document_count.py usr/share/securedrop-client/alembic/versions/
+alembic/versions/15ac9509fc68_init.py usr/share/securedrop-client/alembic/versions/
 files/securedrop-client usr/bin/
 files/securedrop-client.desktop usr/share/applications/


### PR DESCRIPTION
## Description

When trying to run the client from the debian package install, Kushal and I ran into an error where it was trying to look for a couple alembic migration files that had been deleted. We ended making the changes in this PR in order to build the 0.0.7 release of the client to get passed this error.

## Test Plan

1. build debian package of the client with this changes to the install file
2. install
3. run and see no error about trying to find the alembic files that were removed in this PR

/cc @kushaldas @redshiftzero 