### PR TITLE
Add pipeline for building Debian packages in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,92 @@
+---
+common-steps:
+  - &installdeps
+    run:
+      name: Install Debian packaging dependencies
+      command: make install-deps
+
+  - &fetchwheels
+    run:
+      name: Download wheels and sources
+      command: make fetch-wheels
+
+  - &makesourcetarball
+    run:
+      name: Get latest tag for the project and make a source tarball
+      command: |
+        cd ~/packaging/securedrop-*
+        export LATEST_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))"
+        # Enable access to this env var in subsequent run steps
+        echo $LATEST_TAG > ~/packaging/sd_version
+        echo 'export LATEST_TAG=$(cat ~/packaging/sd_version)' >> $BASH_ENV
+        # Create tarball
+        git checkout $LATEST_TAG
+        python3 setup.py sdist
+
+version: 2.1
+jobs:
+  build-securedrop-client:
+    docker:
+      - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+
+      - run:
+          name: Clone the repository to be packaged
+          command: |
+            mkdir ~/packaging && cd ~/packaging
+            git clone https://github.com/freedomofpress/securedrop-client.git
+
+      - *makesourcetarball
+
+      - run:
+          name: Build securedrop-client debian package
+          command: |
+            export PKG_PATH=~/packaging/securedrop-client/dist/securedrop-client-$LATEST_TAG.tar.gz
+            export PKG_VERSION=$LATEST_TAG
+            make securedrop-client
+            ls ~/debbuild/packaging/*.deb
+
+  build-securedrop-proxy:
+    docker:
+      - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+
+      - run:
+          name: Clone the repository to be packaged
+          command: |
+            mkdir ~/packaging && cd ~/packaging
+            git clone https://github.com/freedomofpress/securedrop-proxy.git
+
+      - *makesourcetarball
+
+      - run:
+          name: Build securedrop-proxy debian package
+          command: |
+            export PKG_PATH=~/packaging/securedrop-proxy/dist/securedrop-proxy-$LATEST_TAG.tar.gz
+            export PKG_VERSION=$LATEST_TAG
+            make securedrop-proxy
+            ls ~/debbuild/packaging/*.deb
+
+workflows:
+  build-debian-packages:
+    jobs:
+      - build-securedrop-client
+      - build-securedrop-proxy
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-securedrop-client
+      - build-securedrop-proxy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SecureDrop Debian Packaging
 
+[![CircleCI](https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/tree/master.svg?style=svg)](https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/tree/master)
+
 This repository contains the packaging files and tooling for building Debian packages for projects for the alpha [SecureDrop Workstation](https://github.com/freedomofpress/securedrop-workstation) based on Qubes OS. Packages are placed on `apt-test-qubes.freedom.press` for installation in Debian-based TemplateVMs. These packages are not yet ready for use in a production environment.
 
 ## Packaging a Python-based SecureDrop project

--- a/scripts/verify-sha256sum-signature
+++ b/scripts/verify-sha256sum-signature
@@ -46,7 +46,7 @@ function verify_sha256sum_no_changes() {
     fi
     cd "${repo_root}/localwheels"
     sha256sum * > "$temp_sha256sum"
-    diff "$sha256sums_file" "$temp_sha256sum"
+    diff <(sort "$sha256sums_file") <(sort "$temp_sha256sum")
 }
 
 verify_sha256sum_signature


### PR DESCRIPTION
This gets us towards #8 and will help catch build breakage (e.g. c0b2e6b6d7a1de4f69b816404a1c35a2e9472a87 which fixes broken securedrop-client package builds) that is currently getting merged due to no CI.

Temporarily blocked until we release new versions of `securedrop-client` and `securedrop-proxy` (see below).

*Updated description as PR dependency has since been merged.  - @eloquence 2019-06-11*