### PR TITLE
changelog for sdc 0.0.8 and proxy 0.1.4

### DIFF
--- a/securedrop-client/debian/changelog
+++ b/securedrop-client/debian/changelog
@@ -1,3 +1,10 @@
+securedrop-client (0.0.8) unstable; urgency=medium
+
+  * Update SDK to 0.0.10, urllib to 1.24.3, and SQLAlchemy to 1.3.3 (#424)
+  * Remove pipenv in favor of pip-tools (#372)
+
+ -- Allie Crevier <allie@freedom.press>  Mon, 17 Jun 2019 15:21:41 -0400
+
 securedrop-client (0.0.7) unstable; urgency=medium
 
   * Update securedrop-sdk to 0.0.8 (#357)
@@ -23,7 +30,7 @@ securedrop-client (0.0.6) unstable; urgency=medium
 
 securedrop-client (0.0.5-1) unstable; urgency=medium
 
-  * Package updated to apt-test-qubes did not include securedrop-sdk 0.4 
+  * Package updated to apt-test-qubes did not include securedrop-sdk 0.4
 
  -- mickael e. <user@localhost>  Mon, 12 Nov 2018 17:25:49 -0500
 

--- a/securedrop-proxy/debian/changelog
+++ b/securedrop-proxy/debian/changelog
@@ -1,3 +1,10 @@
+securedrop-proxy (0.1.4) unstable; urgency=medium
+
+  * Update urllib3 to version 1.24.3 or later due to CVE-2019-11324 (#35)
+  * Remove pipenv in favor of pip-tools (#33)
+
+ -- Allie Crevier <allie@freedom.press>  Tues, 18 Jun 2019 15:55:27 -0400
+
 securedrop-proxy (0.1.3) UNRELEASED; urgency=medium
 
   * Updated PyYAML to 5.1 and safe loading of YAML files


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/268

Add changelog entries for the latest releases of the proxy and client. Still need to upload the packages to the test apt server.