### PR TITLE
securedrop-client.install: use wildcard for alembic migrations

### DIFF
--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -2,6 +2,6 @@ files/alembic.ini usr/share/securedrop-client/
 alembic/env.py usr/share/securedrop-client/alembic/
 alembic/README usr/share/securedrop-client/alembic/
 alembic/script.py.mako usr/share/securedrop-client/alembic/
-alembic/versions/2f363b3d680e_init.py usr/share/securedrop-client/alembic/versions/
+alembic/versions/*.py usr/share/securedrop-client/alembic/versions/
 files/securedrop-client usr/bin/
 files/securedrop-client.desktop usr/share/applications/


### PR DESCRIPTION
Closes #53

Needed to address this because https://github.com/freedomofpress/securedrop-client/pull/427 is adding a new migration, and I don't want the nightly build to be added soon in #58 to start producing a non-working package when we merge that PR

For the lazy (this is how I tested this), the `build-securedrop-client` CI job here is handy, one can wait until the package is built in the `build-securedrop-client` job, SSH in to the circle CI box and:

0. `cd ~/debbuild/packaging`
1. `ar x <name_of_deb>`
2. `tar xvf data.tar.xz`
3. `ls usr/share/securedrop-client/alembic/versions/`
4. Confirm you see the migration, even though we didn't specify it manually