### PR TITLE
Update grsec kernels to 4.14.128

### DIFF
--- a/securedrop-workstation-grsec/50-disable-mds-smt.cfg
+++ b/securedrop-workstation-grsec/50-disable-mds-smt.cfg
@@ -1,0 +1,3 @@
+# disables smt and provide full mds mitigations
+# see https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mds=full,nosmt"

--- a/securedrop-workstation-grsec/debian/changelog
+++ b/securedrop-workstation-grsec/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.128-1) unstable; urgency=medium
+
+  * Update grsec kernels to 4.14.128
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 25 Jun 2019 10:42:10 -0400
+
 securedrop-workstation-grsec (4.14.74-1) unstable; urgency=medium
 
   [ Freedom of the Press Foundation ]

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,11 +8,11 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 4.14.74
+upstream_version: 4.14.128
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
-Depends: linux-image-4.14.74-grsec,linux-headers-4.14.74-grsec,libelf-dev,paxctld
+Depends: linux-image-4.14.128-grsec,linux-headers-4.14.128-grsec,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -21,7 +21,7 @@ set -e
 case "$1" in
     configure)
     # DKMS autoinstall the qubes kernel modules
-    dkms autoinstall 4.14.74-grsec
+    dkms autoinstall 4.14.128-grsec
     # enable and restart paxctld to set pax flags (incl grub)
     systemctl enable paxctld
     systemctl restart paxctld

--- a/securedrop-workstation-grsec/debian/securedrop-workstation-grsec.install
+++ b/securedrop-workstation-grsec/debian/securedrop-workstation-grsec.install
@@ -1,0 +1,1 @@
+50-disable-mds-smt.cfg etc/default/grub.d


### PR DESCRIPTION
Ready for review

Updates version strings and changelog for grsec kernels for the securedrop-workstation qubes template.

Configs are in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/49

Kernels packaging (incliding this `securedrop-workstation-grsec` metapackage) are live on apt-test-qubes.freedom.press.