### PR TITLE
ci: increment version and build nightly securedrop-proxy deb package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,19 @@ jobs:
       - *makesourcetarball
       - *builddebianpackage
 
+  build-nightly-securedrop-proxy:
+    docker:
+      - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+      - *clonesecuredropproxy
+      - *getnightlyversion
+      - *makesourcetarball
+      - *updatedebianchangelog
+      - *builddebianpackage
+
 workflows:
   build-debian-packages:
     jobs:
@@ -136,4 +149,4 @@ workflows:
                 - master
     jobs:
       - build-nightly-securedrop-client
-      - build-securedrop-proxy
+      - build-nightly-securedrop-proxy


### PR DESCRIPTION
Closes #50 

This PR adds a nightly CI job to increment the version of securedrop-proxy and build the debian package (the CI run steps being used here were added in #58)

You can verify this works by looking at this build: https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/99 and observing the built package in `/home/circleci/debbuild/packaging/securedrop-proxy_0.1.4-dev-20190625-173008_all.deb`