### PR TITLE
ci: commit workstation debs to lfs repo after nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,39 @@ common-steps:
         make $PKG_NAME
         ls ~/debbuild/packaging/*.deb
 
+  - &installgitlfs
+    run:
+      name: Install Git LFS.
+      command: |
+        export GIT_LFS_VERSION=2.7.2
+        export GIT_LFS_CHECKSUM=89f5aa2c29800bbb71f5d4550edd69c5f83e3ee9e30f770446436dd7f4ef1d4c
+        wget https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
+        sha256sum git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz | grep $GIT_LFS_CHECKSUM
+        tar xzf git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
+        sudo mv git-lfs /usr/local/bin/git-lfs
+        git lfs install
+
+  - &addsshkeys
+    add_ssh_keys:
+      fingerprints:
+        - "e5:b5:6e:d0:4e:ce:52:40:33:30:5e:6f:c5:73:38:20"
+
+  - &commitworkstationdebs
+    run:
+      name: Commit workstation debs for deployment to apt-test-qubes.freedom.press
+      command: |
+        git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
+        cd securedrop-dev-packages-lfs
+
+        git config user.email "securedrop@freedom.press"
+        git config user.name "sdcibot"
+
+        # Copy built debian packages to the relevant workstation repo and git push.
+        cp ~/debbuild/packaging/*.deb ./workstation/stretch/
+        git add workstation/stretch/*.deb
+        git commit -m "Automated SecureDrop workstation build"
+        git push origin master
+
 version: 2.1
 jobs:
   build-securedrop-client:
@@ -107,6 +140,9 @@ jobs:
       - *makesourcetarball
       - *updatedebianchangelog
       - *builddebianpackage
+      - *installgitlfs
+      - *addsshkeys
+      - *commitworkstationdebs
 
   build-securedrop-proxy:
     docker:
@@ -132,6 +168,9 @@ jobs:
       - *makesourcetarball
       - *updatedebianchangelog
       - *builddebianpackage
+      - *installgitlfs
+      - *addsshkeys
+      - *commitworkstationdebs
 
 workflows:
   build-debian-packages:
@@ -148,5 +187,7 @@ workflows:
               only:
                 - master
     jobs:
-      - build-nightly-securedrop-client
       - build-nightly-securedrop-proxy
+      - build-nightly-securedrop-client:
+          requires:
+             - build-nightly-securedrop-proxy


### PR DESCRIPTION
Closes #51

This PR makes the nightly workflow first build securedrop-proxy, then commit to master in the dev packages LFS repo, then do the same for securedrop-client.

One can observe the bot account commit packages here: https://github.com/freedomofpress/securedrop-dev-packages-lfs/commits/master
