### PR TITLE
Adds sd-svs mimetype handlers to securedrop-client pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ build-wheels: fetch-wheels ## Builds the wheels and adds them to the localwheels
 
 .PHONY: clean
 clean: ## Removes all non-version controlled packaging artifacts
+	rm -rf localwheels/*
 
 .PHONY: help
 help: ## Prints this message and exits

--- a/securedrop-client/debian/changelog
+++ b/securedrop-client/debian/changelog
@@ -1,3 +1,16 @@
+securedrop-client (0.0.9) unstable; urgency=medium
+
+  * Use Montserrat and Source Sans Pro (#493)
+  * Same BG for scrollarea, conversation view, selected source (#494,#496)
+  * Supports opening submissions in DispVMs from Qubes dev env (#490)
+  * Center all popup windows (#487)
+  * Use priority queue for job processing (#486)
+  * Use SecureQLabel (#485)
+  * Extract and display original document filenames (#452)
+  * Save in-progress replies via persisting SourceConversationWrapper (#431)
+
+ -- Mickael E. <mickael@freedom.press>  Wed, 31 Jul 2019 11:39:45 -0400
+
 securedrop-client (0.0.8) unstable; urgency=medium
 
   * Update SDK to 0.0.10, urllib to 1.24.3, and SQLAlchemy to 1.3.3 (#424)

--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -3,5 +3,8 @@ alembic/env.py usr/share/securedrop-client/alembic/
 alembic/README usr/share/securedrop-client/alembic/
 alembic/script.py.mako usr/share/securedrop-client/alembic/
 alembic/versions/*.py usr/share/securedrop-client/alembic/versions/
+files/mimeapps.list usr/share/applications/
+files/open-in-dvm.desktop usr/share/applications/
+files/sd-svs-qubes-gpg-domain.sh etc/profile.d/
 files/securedrop-client usr/bin/
 files/securedrop-client.desktop usr/share/applications/


### PR DESCRIPTION
The files referenced here were added to the manifest file in the
"securedrop-client" repository, ensuring they are included in the
tarball used for creating a Debian package.

See corresponding client changes in https://github.com/freedomofpress/securedrop-client/pull/490

### Testing

0. Set up build environment as per this repo's README
1. Create a source tarball using this branch of securedrop-client: https://github.com/freedomofpress/securedrop-client/pull/490
2. set PKG_VERSION: `export PKG_VERSION=0.0.8`
3. run make: `make securedrop-client`
