### PR TITLE
ci: trivial commit to retrigger nightly debian package builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 5 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
trying to fix #77

basically the issue here as I understand it is that we have a build error occurring at the tip of `master` due to running out of seats last month in circle ci. if you re-run the job, it'll still error (because the commit is from a time period where we had no seats... seems like not the ideal behavior but let's put that aside for now) meaning that in order to get our nightly builds running again we need to get a passing build on `master`, which is what this PR does.
