### PR TITLE
Bump securedrop-export to 0.1.2

### DIFF
--- a/securedrop-export/debian/changelog
+++ b/securedrop-export/debian/changelog
@@ -1,3 +1,10 @@
+securedrop-export (0.1.2-1) unstable; urgency=medium
+
+  [ Freedom Of The Press Foundation ]
+  * Adds logging (#17)
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 27 Sep 2019 10:05:12 -0400
+
 securedrop-export (0.1.1-1) unstable; urgency=medium
 
   [ Freedom Of The Press Foundation ]


### PR DESCRIPTION
See https://github.com/freedomofpress/securedrop-export/pull/17 for changes to securedrop-export code