### PR TITLE
Update SecureDrop workstation kernels to 4.14.151

### DIFF
--- a/securedrop-workstation-config/debian/changelog
+++ b/securedrop-workstation-config/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-workstation-config (0.1.0+buster) unstable; urgency=medium
+
+  * Provides buster support through buster-specific package.
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 12:22:23 -0400
+
 securedrop-workstation-config (0.1.0) unstable; urgency=medium
 
   * Initial release.

--- a/securedrop-workstation-config/debian/changelog
+++ b/securedrop-workstation-config/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-workstation-config (0.1.1+buster) unstable; urgency=medium
+
+  * Remove libgnomevfs2-bin from dependencies and bump to 0.1.1
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 14:56:04 -0400
+
 securedrop-workstation-config (0.1.0+buster) unstable; urgency=medium
 
   * Provides buster support through buster-specific package.

--- a/securedrop-workstation-config/debian/control
+++ b/securedrop-workstation-config/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/freedomofpress/securedrop-workstation-config
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: nautilus, gvfs-bin, libgnomevfs2-bin
+Depends: nautilus, gvfs-bin
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.

--- a/securedrop-workstation-grsec/debian/changelog
+++ b/securedrop-workstation-grsec/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.151-3+buster) unstable; urgency=medium
+
+  * Add buster suffix to package version to ensure uniqueness
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 13:25:49 -0400
+
 securedrop-workstation-grsec (4.14.151-2) unstable; urgency=medium
 
   * Improve grub default variable substitution in postint

--- a/securedrop-workstation-grsec/debian/changelog
+++ b/securedrop-workstation-grsec/debian/changelog
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.151-2) unstable; urgency=medium
+
+  * Improve grub default variable substitution in postint
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 09:48:17 -0400
+
 securedrop-workstation-grsec (4.14.151-1) unstable; urgency=medium
 
   * Update grsec kernels to 4.14.151

--- a/securedrop-workstation-grsec/debian/changelog
+++ b/securedrop-workstation-grsec/debian/changelog
@@ -1,3 +1,10 @@
+securedrop-workstation-grsec (4.14.151-1) unstable; urgency=medium
+
+  * Update grsec kernels to 4.14.151
+  * Update GRUB_DEFAULT value to 4.14.151-grsec in /etc/default/grub
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 30 Oct 2019 16:27:45 -0400
+
 securedrop-workstation-grsec (4.14.128-1) unstable; urgency=medium
 
   * Update grsec kernels to 4.14.128

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
 upstream_version: 4.14.151
-debian_revision: 1
+debian_revision: 2
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
 Depends: linux-image-4.14.151-grsec-workstation,linux-headers-4.14.151-grsec-workstation,libelf-dev,paxctld

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
 upstream_version: 4.14.151
-debian_revision: 2
+debian_revision: 3
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
 Depends: linux-image-4.14.151-grsec-workstation,linux-headers-4.14.151-grsec-workstation,libelf-dev,paxctld

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,11 +8,11 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 4.14.128
+upstream_version: 4.14.151
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
-Depends: linux-image-4.14.128-grsec,linux-headers-4.14.128-grsec,libelf-dev,paxctld
+Depends: linux-image-4.14.151-grsec-workstation,linux-headers-4.14.151-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -20,13 +20,11 @@ set -e
 GRSEC_VERSION='4.14.151-grsec-workstation'
 
 # Sets default grub boot parameter to the kernel version specified
-# in $GRSEC_VERSION. The debian buster default kernel is 4.19, thus
-# superceeds this 4.14.x series grsecurity kernel at boot-time
+# by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus
+# supersedes this 4.14.x series grsecurity kernel at boot-time
 set_grub_default() {
-    # set default grub boot parameter to this kernel: buster default
-    # kernel is 4.19
-    GRUB_OPT="\"Advanced options for Debian GNU\/Linux>Debian GNU\/Linux, with Linux $GRSEC_VERSION\""
-    perl -pi -e "s/^GRUB_DEFAULT=(.*)/GRUB_DEFAULT=$GRUB_OPT/" /etc/default/grub
+    GRUB_OPT="'Advanced options for Debian GNU/Linux>Debian GNU/Linux, with Linux $GRSEC_VERSION'"
+    perl -pi -e "s|^GRUB_DEFAULT=.*|GRUB_DEFAULT=$GRUB_OPT|" /etc/default/grub
 }
 
 # Ensure the paxctld daemon is running

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -17,14 +17,33 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+GRSEC_VERSION='4.14.151-grsec-workstation'
+
+# Sets default grub boot parameter to the kernel version specified
+# in $GRSEC_VERSION. The debian buster default kernel is 4.19, thus
+# superceeds this 4.14.x series grsecurity kernel at boot-time
+set_grub_default() {
+    # set default grub boot parameter to this kernel: buster default
+    # kernel is 4.19
+    GRUB_OPT="\"Advanced options for Debian GNU\/Linux>Debian GNU\/Linux, with Linux $GRSEC_VERSION\""
+    perl -pi -e "s/^GRUB_DEFAULT=(.*)/GRUB_DEFAULT=$GRUB_OPT/" /etc/default/grub
+}
+
+# Ensure the paxctld daemon is running
+start_paxctld() {
+    paxctld_config='/etc/paxctld.conf'
+    if [ -f "$paxctld_config" ]; then
+        systemctl enable paxctld
+        systemctl restart paxctld
+    fi
+}
 
 case "$1" in
     configure)
     # DKMS autoinstall the qubes kernel modules
-    dkms autoinstall 4.14.128-grsec
-    # enable and restart paxctld to set pax flags (incl grub)
-    systemctl enable paxctld
-    systemctl restart paxctld
+    dkms autoinstall $GRSEC_VERSION
+    set_grub_default
+    start_paxctld
     update-grub
     ;;
 


### PR DESCRIPTION
  * Update grsec kernels to 4.14.151
  * Update GRUB_DEFAULT value to 4.14.151-grsec-workstation in /etc/default/grub

### Test plan

- [ ] the perl command for editing /etc/default/grub is resilient , and that there isn't a better way to do this change.
- [ ] installing the debs in https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/22 in an HVM debian-buster qube (cloned from debian-10) result in a working grsecurity kernel (apt-get -f install may be required after to pull in paxctld)