### PR TITLE
Updates to Python 3.7 on Buster for package building for securedrop-client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,19 +142,19 @@ jobs:
 
   build-securedrop-client:
     docker:
-      - image: circleci/python:3.5-stretch
+      - image: circleci/python:3.7-buster
     steps:
       - checkout
       - *installdeps
       - *fetchwheels
       - *clonesecuredropclient
-      - *getlatestreleasedversion
+      - *getnightlyversion
       - *makesourcetarball
       - *builddebianpackage
 
   build-nightly-securedrop-client:
     docker:
-      - image: circleci/python:3.5-stretch
+      - image: circleci/python:3.7-buster
     steps:
       - checkout
       - *installdeps
@@ -244,8 +244,8 @@ workflows:
       - build-nightly-securedrop-proxy
       - build-nightly-securedrop-client:
           requires:
-             - build-nightly-securedrop-proxy
+            - build-nightly-securedrop-proxy
       - build-nightly-securedrop-export:
           requires:
-             - build-nightly-securedrop-proxy
-             - build-nightly-securedrop-client
+            - build-nightly-securedrop-proxy
+            - build-nightly-securedrop-client

--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -4,7 +4,7 @@
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python /usr/bin/python3.5 --setuptools -S --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh_virtualenv --python /usr/bin/python3.7 --setuptools -S --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete


### PR DESCRIPTION
Resolves #88

To test the same, you will have to build the package in a Debian Buster VM or container.
For the CI, I have also updated the per PR build job to build nightly client, as the last release of the securedrop-client (0.0.9) can not be built on Buster (due to wheel dependency).

I am going to update the CI for `securedrop-client` in the next PR.

