### PR TITLE
Revert "Updates to Python 3.7 on Buster for package building for securedrop-client"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,19 +142,19 @@ jobs:
 
   build-securedrop-client:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: circleci/python:3.5-stretch
     steps:
       - checkout
       - *installdeps
       - *fetchwheels
       - *clonesecuredropclient
-      - *getnightlyversion
+      - *getlatestreleasedversion
       - *makesourcetarball
       - *builddebianpackage
 
   build-nightly-securedrop-client:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: circleci/python:3.5-stretch
     steps:
       - checkout
       - *installdeps
@@ -244,8 +244,8 @@ workflows:
       - build-nightly-securedrop-proxy
       - build-nightly-securedrop-client:
           requires:
-            - build-nightly-securedrop-proxy
+             - build-nightly-securedrop-proxy
       - build-nightly-securedrop-export:
           requires:
-            - build-nightly-securedrop-proxy
-            - build-nightly-securedrop-client
+             - build-nightly-securedrop-proxy
+             - build-nightly-securedrop-client

--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -4,7 +4,7 @@
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python /usr/bin/python3.7 --setuptools -S --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh_virtualenv --python /usr/bin/python3.5 --setuptools -S --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete


### PR DESCRIPTION
Reverts freedomofpress/securedrop-debian-packaging#89