### PR TITLE
ci/build changes for securedrop-export

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,9 +241,21 @@ jobs:
       - *addsshkeys
       - *commitworkstationdebs
 
-  build-securedrop-export:
+  build-stretch-securedrop-export:
     docker:
       - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+      - *clonesecuredropexport
+      - *getlatestreleasedversion
+      - *makesourcetarball
+      - *builddebianpackage
+
+  build-buster-securedrop-export:
+    docker:
+      - image: circleci/python:3.7-buster
     steps:
       - checkout
       - *installdeps
@@ -299,9 +311,10 @@ workflows:
       - build-buster-securedrop-client
       - build-securedrop-proxy-stretch
       - build-securedrop-proxy-buster
-      - build-securedrop-export
       - build-stretch-securedrop-workstation-svs-disp
       - build-buster-securedrop-workstation-svs-disp
+      - build-stretch-securedrop-export
+      - build-buster-securedrop-export
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       - *addsshkeys
       - *commitworkstationdebs
 
-  build-securedrop-proxy-stretch:
+  build-stretch-securedrop-proxy:
     docker:
       - image: circleci/python:3.5-stretch
     steps:
@@ -213,7 +213,7 @@ jobs:
       - *makesourcetarball
       - *builddebianpackage
 
-  build-securedrop-proxy-buster:
+  build-buster-securedrop-proxy:
     docker:
       - image: circleci/python:3.7-buster
     steps:
@@ -309,8 +309,8 @@ workflows:
       - tests
       - build-stretch-securedrop-client
       - build-buster-securedrop-client
-      - build-securedrop-proxy-stretch
-      - build-securedrop-proxy-buster
+      - build-stretch-securedrop-proxy
+      - build-buster-securedrop-proxy
       - build-stretch-securedrop-workstation-svs-disp
       - build-buster-securedrop-workstation-svs-disp
       - build-stretch-securedrop-export

--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,0 +1,5 @@
+securedrop-export (0.1.2+buster) unstable; urgency=medium
+
+  * Initial release on Debian buster
+
+ -- redshiftzero <jen@freedom.press>  Thu, 21 Nov 2019 11:05:38 -0500

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv --python /usr/bin/python3.5 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/securedrop-export/debian/securedrop-export.triggers
+++ b/securedrop-export/debian/securedrop-export.triggers
@@ -1,7 +1,7 @@
-# Register interest in Python interpreter changes (Python 2 for now); and
+# Register interest in Python interpreter changes; and
 # don't make the Python package dependent on the virtualenv package
 # processing (noawait)
-interest-noawait /usr/bin/python3.5
+interest-noawait /usr/bin/python3
 
 # Also provide a symbolic trigger for all dh-virtualenv packages
 interest dh-virtualenv-interpreter-update


### PR DESCRIPTION
Closes #92 

Corresponding securedrop-export buster package in: https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/26