### PR TITLE
add build job for python3.7-buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - checkout
       - run:
           name: install test requirements and run tests
-          command: |   
+          command: |
             virtualenv .venv
             source .venv/bin/activate
             pip install -r test-requirements.txt
@@ -194,7 +194,7 @@ jobs:
 
   build-securedrop-proxy-buster:
     docker:
-      - image: circleci/python3.7-buster
+      - image: circleci/python:3.7-buster
     steps:
       - checkout
       - *installdeps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,9 +180,21 @@ jobs:
       - *addsshkeys
       - *commitworkstationdebs
 
-  build-securedrop-proxy:
+  build-securedrop-proxy-stretch:
     docker:
       - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+      - *clonesecuredropproxy
+      - *getlatestreleasedversion
+      - *makesourcetarball
+      - *builddebianpackage
+
+  build-securedrop-proxy-buster:
+    docker:
+      - image: circleci/python3.7-buster
     steps:
       - checkout
       - *installdeps
@@ -242,7 +254,8 @@ workflows:
       - tests
       - build-stretch-securedrop-client
       - build-buster-securedrop-client
-      - build-securedrop-proxy
+      - build-securedrop-proxy-stretch
+      - build-securedrop-proxy-buster
       - build-securedrop-export
 
   nightly:

--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,0 +1,5 @@
+securedrop-proxy (0.1.5) unstable; urgency=medium
+
+  * Initial buster release
+
+ -- Allie Crevier <allie@freedom.press>  Thur, 21 Jun 2019 13:52:27 -0400

--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,5 +1,5 @@
-securedrop-proxy (0.1.5) unstable; urgency=medium
+securedrop-proxy (0.1.5+buster) unstable; urgency=medium
 
-  * Initial buster release
+  * Update python3.5 to python3 and add changelog for buster builds
 
- -- Allie Crevier <allie@freedom.press>  Thur, 21 Jun 2019 13:52:27 -0400
+ -- Allie Crevier <allie@freedom.press>  Thur, 21 Nov 2019 19:25:41 -0500

--- a/securedrop-proxy/debian/changelog-stretch
+++ b/securedrop-proxy/debian/changelog-stretch
@@ -1,3 +1,9 @@
+securedrop-proxy (0.1.5+stretch) unstable; urgency=medium
+
+  * Update python3.5 to python3 and add changelog for buster builds
+
+ -- Allie Crevier <allie@freedom.press>  Thur, 21 Nov 2019 19:40:09 -0500
+
 securedrop-proxy (0.1.4) unstable; urgency=medium
 
   * Update urllib3 to version 1.24.3 or later due to CVE-2019-11324 (#35)

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv --python /usr/bin/python3.5 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/securedrop-proxy/debian/securedrop-proxy.triggers
+++ b/securedrop-proxy/debian/securedrop-proxy.triggers
@@ -1,7 +1,7 @@
 # Register interest in Python interpreter changes (Python 2 for now); and
 # don't make the Python package dependent on the virtualenv package
 # processing (noawait)
-interest-noawait /usr/bin/python3.5
+interest-noawait /usr/bin/python3
 
 # Also provide a symbolic trigger for all dh-virtualenv packages
 interest dh-virtualenv-interpreter-update


### PR DESCRIPTION
## Description

Adds a `securedrop-proxy` build job for Python 3.7 on Buster.

To test, build the `securedrop-proxy` debian package in a Buster VM and run through test plan to make sure it is functioning as normal without regression.