### PR TITLE
fix nighty builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ common-steps:
         cd ~/project/$PKG_NAME
         export DEBFULLNAME='Automated builds'
         export DEBEMAIL=securedrop@freedom.press
+        export PLATFORM="$(lsb_release -sc)"
+        cp ~/project/$PKG_NAME/debian/changelog-$PLATFORM ~/project/$PKG_NAME/debian/changelog
         dch --distribution unstable --package "$PKG_NAME" --newversion $VERSION_TO_BUILD "This is an automated build."
 
   - &builddebianpackage


### PR DESCRIPTION
Fixes #100 

You can confirm this works via either:
 - [this branch](https://github.com/freedomofpress/securedrop-debian-packaging/compare/test-changelog-step) which contains a test job that runs the failing run step, it passes CI [here](https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/942)
- this succeeding "nightly" build that I ran ad hoc based on this branch so we got updated debs with the latest - https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/952