### PR TITLE
AppArmor support and profile for securedrop-client

### DIFF
--- a/securedrop-client/debian/control
+++ b/securedrop-client/debian/control
@@ -9,5 +9,5 @@ X-Python3-Version: >= 3.5
 
 Package: securedrop-client
 Architecture: all
-Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg
+Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, apparmor-utils
 Description: securedrop client for qubes workstation

--- a/securedrop-client/debian/postinst
+++ b/securedrop-client/debian/postinst
@@ -22,6 +22,8 @@ case "$1" in
     configure)
 
     update-desktop-database /usr/share/applications
+    # enforce the apparmor profile for the client
+    aa-enforce /etc/apparmor.d/usr.bin.securedrop-client
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -8,3 +8,4 @@ files/open-in-dvm.desktop usr/share/applications/
 files/sd-svs-qubes-gpg-domain.sh etc/profile.d/
 files/securedrop-client usr/bin/
 files/securedrop-client.desktop usr/share/applications/
+files/usr.bin.securedrop-client /etc/apparmor.d/


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/234 :

* Bump kernel image to support AppArmor (see changes in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/54)
* Logic to copy, squash and enforce AppArmor profile for securedrop-client

### Test plan
subset of https://github.com/freedomofpress/securedrop-workstation/pull/364 , required a vm with apparmor support:

- [ ] install `apparmor-utils` on sd-svs or sd-svs-buster-template
- [ ] build securedrop-client using this branch and https://github.com/freedomofpress/securedrop-client/pull/673
- [ ] Installing the deb results in an apparmor profile enforced the host (`sudo aa-status`)