### PR TITLE
add nightly build for securedrop-log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,22 @@ jobs:
       - *makesourcetarball
       - *builddebianpackage
 
+  build-nightly-buster-securedrop-log:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+      - *clonesecuredroplog
+      - *getnightlyversion
+      - *makesourcetarball
+      - *updatedebianchangelog
+      - *builddebianpackage
+      - *installgitlfs
+      - *addsshkeys
+      - *commitworkstationdebs
+
   build-stretch-securedrop-client:
     docker:
       - image: circleci/python:3.5-stretch
@@ -418,3 +434,6 @@ workflows:
       - build-nightly-buster-securedrop-export:
           requires:
             - build-nightly-buster-securedrop-proxy
+      - build-nightly-buster-securedrop-log:
+          requires:
+            - build-nightly-buster-securedrop-export


### PR DESCRIPTION
Adds nightly build for securedrop-log, see package built on this logic https://github.com/freedomofpress/securedrop-dev-packages-lfs/commit/6faa9b32a08110d57eec36b3f1a02e26424379c4 deployed here https://apt-test-qubes.freedom.press/pool/main/s/securedrop-log/