### PR TITLE
Improve dh-virtualenv for securedrop-client

### DIFF
--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -4,7 +4,15 @@
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python /usr/bin/python3 --setuptools -S --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh_virtualenv \
+		--python /usr/bin/python3 \
+		--setuptools \
+		--use-system-packages \
+		--index-url https://dev-bin.ops.securedrop.org/simple \
+		--extra-pip-arg "--ignore-installed" \
+		--extra-pip-arg "--no-deps" \
+		--extra-pip-arg "--no-cache-dir" \
+		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -1,11 +1,20 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh $@ --with python-virtualenv
+
+override_dh_virtualenv:
+	dh_virtualenv \
+		--python /usr/bin/python3 \
+		--setuptools \
+		--index-url https://dev-bin.ops.securedrop.org/simple \
+		--extra-pip-arg "--ignore-installed" \
+		--extra-pip-arg "--no-deps" \
+		--extra-pip-arg "--no-cache-dir" \
+		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
 	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
 	dh_strip_nondeterminism $@
-

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -1,11 +1,20 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --index-url https://dev-bin.ops.securedrop.org/simple --requirements build-requirements.txt
+	dh $@ --with python-virtualenv
+
+override_dh_virtualenv:
+	dh_virtualenv \
+		--python /usr/bin/python3 \
+		--setuptools \
+		--index-url https://dev-bin.ops.securedrop.org/simple \
+		--extra-pip-arg "--ignore-installed" \
+		--extra-pip-arg "--no-deps" \
+		--extra-pip-arg "--no-cache-dir" \
+		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
 	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
 	dh_strip_nondeterminism $@
-


### PR DESCRIPTION
Add extra pip options "--ignore-installed", "--no-deps", and "--no-cache-dir" to the dh-virtualenv override in rules files for securedrop-client, securedrop-export, and securedrop-proxy. This prevents variation in the build environment from changing the set of requirements included in the virtualenv embedded in the package.

Fixes #111.