### PR TITLE
Provide apparmor kernel support, bump kernel to 4.14.158

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,16 @@ common-steps:
         echo $PKG_NAME > ~/packaging/sd_package_name
         echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
 
+  - &setsdgrsecname
+    run:
+      name: Set package name to securedrop-workstation-grsec
+      command: |
+        mkdir ~/packaging
+        export PKG_NAME="securedrop-workstation-grsec"
+        # Enable access to this env car in subsequent run steps
+        echo $PKG_NAME > ~/packaging/sd_package_name
+        echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
+
   - &setmetapackageversion
       run:
         name: Get metapackage version via distribution changelog
@@ -392,6 +402,28 @@ jobs:
       - *setmetapackageversion
       - *builddebianpackage
 
+  build-stretch-securedrop-workstation-grsec:
+    docker:
+      - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+      - *setsdgrsecname
+      - *setmetapackageversion
+      - *builddebianpackage
+
+  build-buster-securedrop-workstation-grsec:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *installdeps
+      - *fetchwheels
+      - *setsdgrsecname
+      - *setmetapackageversion
+      - *builddebianpackage
+
 workflows:
   build-debian-packages:
     jobs:
@@ -405,6 +437,8 @@ workflows:
       - build-stretch-securedrop-export
       - build-buster-securedrop-export
       - build-buster-securedrop-log
+      - build-stretch-securedrop-workstation-grsec
+      - build-buster-securedrop-workstation-grsec
 
 # Nightly jobs for each package are run in series to ensure there are no
 # conflicts or race conditions when committing deb packages to git-lfs.

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ securedrop-workstation-config: ## Builds Debian metapackage for Qubes Workstatio
 
 .PHONY: securedrop-workstation-grsec
 securedrop-workstation-grsec: ## Builds Debian metapackage for Qubes Workstation hardened kernel
+	PKG_NAME="securedrop-workstation-grsec" ./scripts/build-debianpackage
 
 .PHONY: securedrop-workstation-svs-disp
 securedrop-workstation-svs-disp: ## Builds Debian metapackage for Disposable VM dependencies and tooling

--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,0 +1,12 @@
+securedrop-workstation-grsec (4.14.158-1+buster) unstable; urgency=medium
+
+  * Update kernel version to 4.14.158
+  * Enable AppArmor in kernel config
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 09 Dec 2019 18:46:50 -0500
+
+securedrop-workstation-grsec (4.14.151-3+buster) unstable; urgency=medium
+
+  * Add buster suffix to package version to ensure uniqueness
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 13:25:49 -0400

--- a/securedrop-workstation-grsec/debian/changelog-stretch
+++ b/securedrop-workstation-grsec/debian/changelog-stretch
@@ -1,9 +1,3 @@
-securedrop-workstation-grsec (4.14.151-3+buster) unstable; urgency=medium
-
-  * Add buster suffix to package version to ensure uniqueness
-
- -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 13:25:49 -0400
-
 securedrop-workstation-grsec (4.14.151-2) unstable; urgency=medium
 
   * Improve grub default variable substitution in postint

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,11 +8,11 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 4.14.151
-debian_revision: 3
+upstream_version: 4.14.158
+debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
-Depends: linux-image-4.14.151-grsec-workstation,linux-headers-4.14.151-grsec-workstation,libelf-dev,paxctld
+Depends: linux-image-4.14.158-grsec-workstation,linux-headers-4.14.158-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -17,7 +17,7 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-GRSEC_VERSION='4.14.151-grsec-workstation'
+GRSEC_VERSION='4.14.158-grsec-workstation'
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/234

* Add makefile target to build kernel metapackage, decouple stretch and buster changelogs
* Add CI job for securedrop-workstation-grsec (both stretch and buster)