### PR TITLE
Update debian changelog and don't enforce apparmor profile in postinst

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,13 @@
+securedrop-client (0.0.11+buster) unstable; urgency=medium
+
+  * Add apparmor profile (#673)
+  * Add failure message for replies (#664)
+  * Move metadata sync to api queue (#640)
+  * Add print integration (#631)
+  * Populate source list immediately upon login (#626)
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 19 Dec 2019 12:20:20 -0500
+
 securedrop-client (0.0.10+buster) unstable; urgency=medium
 
   * Add Python 3.7/buster support (#568, #609)

--- a/securedrop-client/debian/postinst
+++ b/securedrop-client/debian/postinst
@@ -22,8 +22,6 @@ case "$1" in
     configure)
 
     update-desktop-database /usr/share/applications
-    # enforce the apparmor profile for the client
-    aa-enforce /etc/apparmor.d/usr.bin.securedrop-client
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/pull/364
In #116 we've introduced apparmor support but discovered, after merging 2 issues:

1. if the kernel is not running 4.14.158 or above, the postinst for the client will fail when attempting to enforce the apparmor profile, resulting in a potentially broken template
2. The debian changelog was not updated.

To immediately resolve (and not break nightlies), let's merge this ASAP and enforce the apparmor profile via /rw/config/rc.local in the securedrop-workstation salt logic as part of https://github.com/freedomofpress/securedrop-workstation/pull/364


### Test plan:
* build securedrop-client on this branch: `PKG_VERSION=0.0.11 PKG_PATH=../securedrop-client/dist/securedrop-client-0.0.11.tar.gz make securedrop-client`
- [ ] file name is `securedrop-client_0.0.11+buster_all.deb`
- [ ] securedrop-client built on this branch can be installed (and postinst does not fail) in a qubes PVH kernel or any other kernel without apparmor support 
- [ ] /etc/apparmor.d/usr.bin.securedrop-client is still present
