### PR TITLE
Install apparmor profiles in sd-svs-disp

### DIFF
--- a/securedrop-workstation-svs-disp/debian/changelog-buster
+++ b/securedrop-workstation-svs-disp/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-svs-disp (0.1.4+buster) unstable; urgency=medium
+
+  * Add apparmor-utils, apparmor-profiles and apparmor-profiles-extra to list of dependencies.
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 20 Dec 2019 10:24:05 -0500
+
 securedrop-workstation-svs-disp (0.1.3+buster) unstable; urgency=medium
 
   * Provides Debian 10 (Buster) compatibility.

--- a/securedrop-workstation-svs-disp/debian/control
+++ b/securedrop-workstation-svs-disp/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
 
 Package: securedrop-workstation-svs-disp
 Architecture: all
-Depends: securedrop-workstation-config,securedrop-workstation-grsec,audacious,eog,file-roller,totem
+Depends: securedrop-workstation-config,securedrop-workstation-grsec,audacious,eog,file-roller,totem,apparmor-utils,apparmor-profiles,apparmor-profiles-extra
 Description: This is the SecureDrop workstation SVS Disposable VM template configuration package. This package provides dependencies and configuration for the Qubes SecureDrop workstation sd-svs-disp Template VM.

--- a/securedrop-workstation-svs-disp/debian/postinst
+++ b/securedrop-workstation-svs-disp/debian/postinst
@@ -21,7 +21,7 @@ set -e
 case "$1" in
     configure)
     # move pax flags and restart paxctld
-    mv /etc/paxctld.conf.svsdisp /etc/paxctld.conf
+    mv /opt/paxctld.conf.svsdisp /etc/paxctld.conf
     systemctl restart paxctld
     ;;
 

--- a/securedrop-workstation-svs-disp/debian/securedrop-workstation-svs-disp.install
+++ b/securedrop-workstation-svs-disp/debian/securedrop-workstation-svs-disp.install
@@ -1,2 +1,2 @@
 mimeapps.list usr/share/applications/
-paxctld.conf.svsdisp etc/
+paxctld.conf.svsdisp opt/


### PR DESCRIPTION
closes https://github.com/freedomofpress/securedrop-workstation/issues/384
This will ensure upstream apparmor profiles are installed and enforced. This includes profiles for:
* libreoffice
* totem
* evince

It appears that in compat level 10 (default for buster), files are not copied to /etc . Since we want to automatically squash the paxctld configuration, let's move it to `/opt` and move in place to `/etc` in postinst.
### Test plan
- check out this branch
- [ ] package successfully builds (`PKG_VERSION=0.1.4 make securedrop-workstation-svs-disp`)
- move package to sd-svs-disp-buster-template and install package in that template (`sudo apt-get -f install to resolve dependencies`)
- [ ] package installs successfully, `sudo aa-status` shows profiles
- in sd-svs-disp, open a pdf in evince
- [ ] evince apparmor profile is enforced for the process (when evince is open, `sudo aa-status`)