### PR TITLE
Disable notifications in sd-export VMs

### DIFF
--- a/securedrop-export/debian/postinst
+++ b/securedrop-export/debian/postinst
@@ -17,16 +17,22 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+NOTIFICATION_SERVICE_PATH='/usr/share/dbus-1/services/org.freedesktop.mate.Notifications.service'
 
 case "$1" in
     configure)
-    
+
     update-desktop-database /usr/share/applications
     update-mime-database /usr/share/mime
+    # Disable notifictions service, since the printer configuration
+    # is not required and will not persist
+    if [ -e ${NOTIFICATION_SERVICE_PATH} ]; then
+        mv "${NOTIFICATION_SERVICE_PATH}" "${NOTIFICATION_SERVICE_PATH}.disabled"
+    fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)
-  
+
     update-desktop-database /usr/share/applications
     update-mime-database /usr/share/mime
     ;;


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/securedrop-export/issues/37

This will ensure there are no popups to display to reduce user confusion because:
- sd-export-usb is a disposableVM, and the changes won't persist
- printer drivers are automatically installed by securedrop-export

This is the easy way to ensure no popups will be displayed, but will mean that popup messages such as https://github.com/freedomofpress/securedrop-export/blob/e4239d88dfb22cdfc03859609184ca7494045058/securedrop_export/print/actions.py#L163 will no longer work. I believe the plan of record was to get rid of them, I will open a follow-up PR to remove those in sd-export.

#### Test plan
- [ ] build securedrop-export deb on this branch is successful
- [ ] Package installs successfully in sd-export-usb
- [ ] plugging a printer to sd-export-usb no longer has popup to present printer
- [ ] Printing a document from the client works 