### PR TITLE
[wip] build RPM for dom0 in nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,13 @@ common-steps:
         git commit -m "Automated SecureDrop workstation build"
         git push origin master
 
+  - &sign_rpm
+    run: 
+      name: Sign rpms with test GPG key
+      command: |
+        echo "$SD_TEST_GPG_PRIVKEY" | base64 -d | gpg --import
+        # TODO: rpm --resign goes here but needs to be done in container
+
   - &commitworkstationrpms
     run:
       name: Commit workstation rpms for deployment to yum-test.securedrop.org
@@ -355,6 +362,7 @@ jobs:
       - *clonesecuredropworkstation
       - *getrpmnightlyversion
       - *buildrpm
+      - *sign_rpm
       - *installgitlfs
       # - *addsshkeys
       # - *commitworkstationrpms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,24 @@ common-steps:
 
   - &getnightlyversion
     run:
-      name: Create nightly version
+      name: Create nightly version for debian packages
       command: |
         cd ~/packaging/securedrop-*
         # Nightly versioning format is: LATEST_TAG-dev-YYMMDD-HHMMSS
         export VERSION_TO_BUILD="$(git describe --tags $(git rev-list --tags --max-count=1))-dev-$(date +%Y%m%d)-$(date +%H%M%S)"
+        # Enable access to this env var in subsequent run steps
+        echo $VERSION_TO_BUILD > ~/packaging/sd_version
+        echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
+        ./update_version.sh $VERSION_TO_BUILD
+        git tag $VERSION_TO_BUILD
+
+  - &getrpmnightlyversion
+    run:
+      name: Create nightly version for rpm packages
+      command: |
+        cd ~/packaging/securedrop-*
+        # Nightly versioning format for RPMs is since rpm does not like '-' in versions: LATEST_TAG.YYMMDD.HHMMSS
+        export VERSION_TO_BUILD="$(git describe --tags $(git rev-list --tags --max-count=1)).$(date +%Y%m%d).$(date +%H%M%S)"
         # Enable access to this env var in subsequent run steps
         echo $VERSION_TO_BUILD > ~/packaging/sd_version
         echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
@@ -326,8 +339,8 @@ jobs:
     steps:
       - checkout
       - *clonesecuredropworkstation
-      - *getnightlyversion
-      # Add changelog entry step
+      - *getrpmnightlyversion
+      # Add changelog entry step?
       - *buildrpm
       - *installgitlfs
       # - *addsshkeys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,17 @@ common-steps:
         echo $PKG_NAME > ~/packaging/sd_package_name
         echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
 
+  - &clonesecuredropworkstation
+    run:
+      name: Clone the repository to be packaged
+      command: |
+        mkdir ~/packaging && cd ~/packaging
+        git clone https://github.com/freedomofpress/securedrop-workstation.git
+        export PKG_NAME="securedrop-workstation"
+        # Enable access to this env car in subsequent run steps
+        echo $PKG_NAME > ~/packaging/sd_package_name
+        echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
+
   - &updatedebianchangelog
     run:
       name: Update debian changelog
@@ -151,6 +162,29 @@ common-steps:
         git add workstation/${PLATFORM}/*.deb
         git commit -m "Automated SecureDrop workstation build"
         git push origin master
+
+  - &commitworkstationrpms
+    run:
+      name: Commit workstation rpms for deployment to yum-test.securedrop.org
+      command: |
+        git clone git@github.com:freedomofpress/securedrop-dev-rpm-packages-lfs.git
+        cd securedrop-dev-rpm-packages-lfs
+
+        git config user.email "securedrop@freedom.press"
+        git config user.name "sdcibot"
+
+        # Copy built debian packages to the relevant workstation repo and git push.
+        cp ~/debbuild/packaging/*.rpm ./workstation/
+        git add workstation/*.rpm
+        git commit -m "Automated SecureDrop workstation build"
+        #git push origin master
+
+  - &buildrpm
+    run:
+      name: Build dom0 rpm
+      command: |
+        cd ~/packaging/$PKG_NAME
+        make dom0-rpm
 
 version: 2.1
 jobs:
@@ -287,8 +321,20 @@ jobs:
       - *setmetapackageversion
       - *builddebianpackage
 
+  build-nightly-dom0-rpm:
+    machine: true
+    steps:
+      - checkout
+      - *clonesecuredropworkstation
+      - *getnightlyversion
+      # Add changelog entry step
+      - *buildrpm
+      - *installgitlfs
+      # - *addsshkeys
+      # - *commitworkstationrpms
+
 workflows:
-  build-debian-packages:
+  build-packages:
     jobs:
       - tests
       - build-buster-securedrop-client
@@ -297,6 +343,7 @@ workflows:
       - build-buster-securedrop-export
       - build-buster-securedrop-log
       - build-buster-securedrop-workstation-grsec
+      - build-nightly-dom0-rpm
 
 # Nightly jobs for each package are run in series to ensure there are no
 # conflicts or race conditions when committing deb packages to git-lfs.
@@ -320,3 +367,6 @@ workflows:
       - build-nightly-buster-securedrop-log:
           requires:
             - build-nightly-buster-securedrop-export
+      - build-nightly-dom0-rpm:
+          requires:
+            - build-nightly-buster-securedrop-log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,18 @@ common-steps:
           echo $VERSION_TO_BUILD > ~/packaging/sd_version
           echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
 
+  - &installgitlfs
+    run:
+      name: Install Git LFS.
+      command: |
+        export GIT_LFS_VERSION=2.9.2
+        export GIT_LFS_CHECKSUM=04346234130e518d165bdc7e9964375bbeb3b98efabd042084530cc34288274c
+        wget https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
+        sha256sum git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz | grep $GIT_LFS_CHECKSUM
+        tar xzf git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
+        sudo mv git-lfs /usr/local/bin/git-lfs
+        git lfs install
+
   - &commitworkstationdebs
     run:
       name: Commit workstation debs for deployment to apt-test-qubes.freedom.press
@@ -335,9 +347,11 @@ jobs:
       - *builddebianpackage
 
   build-nightly-dom0-rpm:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - checkout
+      - *installgitlfs
       - *clonesecuredropworkstation
       - *getrpmnightlyversion
       - *buildrpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ common-steps:
       name: Create nightly version for rpm packages
       command: |
         cd ~/packaging/securedrop-*
-        # Nightly versioning format for RPMs is since rpm does not like '-' in versions: LATEST_TAG.YYMMDD.HHMMSS
-        export VERSION_TO_BUILD="$(git describe --tags $(git rev-list --tags --max-count=1)).$(date +%Y%m%d).$(date +%H%M%S)"
+        # Nightly versioning format for RPMs is since rpm does not like '-' in versions: LATEST_TAG.dev.YYMMDD.HHMMSS
+        export VERSION_TO_BUILD="$(git describe --tags $(git rev-list --tags --max-count=1)).dev.$(date +%Y%m%d).$(date +%H%M%S)"
         # Enable access to this env var in subsequent run steps
         echo $VERSION_TO_BUILD > ~/packaging/sd_version
         echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,11 +186,11 @@ common-steps:
         git config user.email "securedrop@freedom.press"
         git config user.name "sdcibot"
 
-        # Copy built debian packages to the relevant workstation repo and git push.
-        cp ~/debbuild/packaging/*.rpm ./workstation/
-        git add workstation/*.rpm
+        # Copy built RPM packages to the relevant workstation repo and git push.
+        cp ~/rpm-build/RPMS/noarch/*.rpm ./workstation/dom0/f25/
+        git add workstation/dom0/f25/*.rpm
         git commit -m "Automated SecureDrop workstation build"
-        #git push origin master
+        git push origin master
 
   - &buildrpm
     run:
@@ -340,7 +340,6 @@ jobs:
       - checkout
       - *clonesecuredropworkstation
       - *getrpmnightlyversion
-      # Add changelog entry step?
       - *buildrpm
       - *installgitlfs
       # - *addsshkeys


### PR DESCRIPTION
Closes https://github.com/freedomofpress/securedrop-workstation/issues/357 (so that we can iterate on the RPM logic quickly)

items of note:
* right now this is running per-PR with the actual committing to the lfs repo commented out (along with all the other build jobs for speed), will fix that and take this out of draft state once the dependent PR is merged - you can see a successful build [here](https://circleci.com/gh/redshiftzero/securedrop-debian-packaging/72)
* I had to deviate from our versioning strategy used for the debian package nightlies as `-` is an invalid character, so I went with `LATEST_TAG.dev.YYMMDD.HHMMSS` which is as close as possible for consistency
* I don't plan to add a per-PR rpm build job here (only a nightly job will be added), as we have one over in securedrop-workstation, which is where the RPM build logic resides, so I see no value in duplicating that here.

