### PR TITLE
Explicitly requires hashes for pip builds

### DIFF
--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -12,6 +12,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--require-hashes" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -11,6 +11,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--require-hashes" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -11,6 +11,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--require-hashes" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
Ensures that hashes are pinned in the requirements files used to pull in
pip dependencies for packages. Pip will already use the hashes if found,
but providing the pip option ensures that a build will fail if a reqs
file is provided that doesn't have pinned hashes.

Closes #79.