### PR TITLE
VM rename per https://github.com/freedomofpress/securedrop-workstation/issues/285

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,15 @@
+securedrop-client (0.0.12+buster) unstable; urgency=medium
+
+  * Use revised VM names (securedrop-workstation #285)
+  * Delete sources using the general queue (#402)
+  * Add a preview snippet for sources (#135)
+  * Add a show/hide password feature on the login screen (#659)
+  * Disable sync icon during active sync (#388)
+  * Add keyboard shortcuts for sending replies (#606)
+  * Add hover states for UI elements (#591)
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 17 Jan 2020 18:20:20 -0800
+
 securedrop-client (0.0.11+buster) unstable; urgency=medium
 
   * Add apparmor profile (#673)

--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -5,7 +5,7 @@ alembic/script.py.mako usr/share/securedrop-client/alembic/
 alembic/versions/*.py usr/share/securedrop-client/alembic/versions/
 files/mimeapps.list usr/share/applications/
 files/open-in-dvm.desktop usr/share/applications/
-files/sd-svs-qubes-gpg-domain.sh etc/profile.d/
+files/sd-app-qubes-gpg-domain.sh etc/profile.d/
 files/securedrop-client usr/bin/
 files/securedrop-client.desktop usr/share/applications/
 files/usr.bin.securedrop-client /etc/apparmor.d/

--- a/securedrop-workstation-svs-disp/debian/control
+++ b/securedrop-workstation-svs-disp/debian/control
@@ -9,4 +9,4 @@ Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
 Package: securedrop-workstation-svs-disp
 Architecture: all
 Depends: securedrop-workstation-config,securedrop-workstation-grsec,audacious,eog,file-roller,totem,apparmor-utils,apparmor-profiles,apparmor-profiles-extra
-Description: This is the SecureDrop workstation SVS Disposable VM template configuration package. This package provides dependencies and configuration for the Qubes SecureDrop workstation sd-svs-disp Template VM.
+Description: This is the SecureDrop workstation SecureDrop Viewer Disposable VM template configuration package. This package provides dependencies and configuration for the Qubes SecureDrop workstation sd-viewer Template VM.


### PR DESCRIPTION
Excluding svs-disp package name for now

Blocked on freedomofpress/securedrop-workstation#407