### PR TITLE
Builds nightly debs for sd-svs-disp package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ common-steps:
 
   - &getnightlyversion
     run:
-      name: Create nightly version for debian packages
+      name: Create nightly version for python packages
       command: |
         cd ~/packaging/securedrop-*
         # Nightly versioning format is: LATEST_TAG-dev-YYMMDD-HHMMSS
@@ -40,6 +40,18 @@ common-steps:
         echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
         ./update_version.sh $VERSION_TO_BUILD
         git tag $VERSION_TO_BUILD
+
+  - &getnightlymetapackageversion
+    run:
+      name: Create nightly version for metapackages
+      command: |
+        PLATFORM="$(lsb_release -sc)"
+        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ~/project/${PKG_NAME}/debian/changelog-${PLATFORM} | head -n1)
+        # Nightly versioning format is: LATEST_TAG-dev-YYMMDD-HHMMSS
+        export VERSION_TO_BUILD="$CURRENT_VERSION-dev-$(date +%Y%m%d)-$(date +%H%M%S)"
+        # Enable access to this env var in subsequent run steps
+        echo $VERSION_TO_BUILD > ~/packaging/sd_version
+        echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
 
   - &makesourcetarball
     run:
@@ -350,7 +362,8 @@ jobs:
       - checkout
       - *installdeps
       - *setsvsdispname
-      - *setmetapackageversion
+      - *getnightlymetapackageversion
+      - *updatedebianchangelog
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,4 +426,6 @@ workflows:
       - build-nightly-dom0-rpm:
           requires:
             - build-nightly-buster-securedrop-log
-      - build-nightly-buster-securedrop-workstation-svs-disp
+      - build-nightly-buster-securedrop-workstation-svs-disp:
+          requires:
+            - build-nightly-dom0-rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,6 +343,18 @@ jobs:
       - *setmetapackageversion
       - *builddebianpackage
 
+  build-nightly-buster-securedrop-workstation-svs-disp:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *installdeps
+      - *setsvsdispname
+      - *setmetapackageversion
+      - *builddebianpackage
+      - *addsshkeys
+      - *commitworkstationdebs
+
   build-buster-securedrop-workstation-grsec:
     docker:
       - image: circleci/python:3.7-buster
@@ -414,3 +426,4 @@ workflows:
       - build-nightly-dom0-rpm:
           requires:
             - build-nightly-buster-securedrop-log
+      - build-nightly-buster-securedrop-workstation-svs-disp


### PR DESCRIPTION
We were already building the package on PR runs, but not as nightlies.
Adds a nightly job to changes propagate to the dev lfs repo.
Identified in https://github.com/freedomofpress/securedrop-workstation/issues/282#issuecomment-577461715

