### PR TITLE
Adds changes for updated securedrop-log package

### DIFF
--- a/securedrop-log/debian/changelog-buster
+++ b/securedrop-log/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-log (0.0.4+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- Kushal Das <kushal@freedom.press>  Tue, 22 Jan 2019 13:05:38 +0530
+
 securedrop-log (0.0.3+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-log/debian/control
+++ b/securedrop-log/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-log
 Section: utils
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools, dh-virtualenv
+Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools, dh-virtualenv, python3-distutils
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-log
 Vcs-Git: https://github.com/freedomofpress/securedrop-log.git
@@ -10,7 +10,7 @@ X-Python-3-Version: >= 3.7
 
 Package: securedrop-log
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}
+Depends: ${python3:Depends}, ${misc:Depends}, python3-distutils
 Description: Python module and qrexec service to store logs for SecureDrop Workstation
  This package provides Python module and qrexec service files to create a logging VM in
  SecureDrop Workstation project in Qubes.

--- a/securedrop-log/debian/rules
+++ b/securedrop-log/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --index-url https://pypi.securedrop.org/simple --requirements build-requirements.txt
+	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --extra-pip-arg "--no-deps" --index-url https://pypi.securedrop.org/simple --requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/securedrop-log/debian/securedrop-log.install
+++ b/securedrop-log/debian/securedrop-log.install
@@ -1,1 +1,5 @@
 securedrop.Log etc/qubes-rpc/
+sd-rsyslog usr/sbin/
+securedrop-log.service etc/systemd/system
+sdlog.conf etc/rsyslog.d/
+

--- a/securedrop-log/debian/securedrop-log.links
+++ b/securedrop-log/debian/securedrop-log.links
@@ -1,1 +1,3 @@
 opt/venvs/securedrop-log/sbin/securedrop-log usr/sbin/securedrop-log
+opt/venvs/securedrop-log/sbin/securedrop-log-saver usr/sbin/securedrop-log-saver
+opt/venvs/securedrop-log/sbin/securedrop-redis-log usr/sbin/securedrop-redis-log


### PR DESCRIPTION
This will not pass till get https://github.com/freedomofpress/securedrop-log/pull/8 and https://github.com/freedomofpress/securedrop-debian-packaging/pull/132 merged.

## How to test?

```
$ PKG_VERSION=0.0.4 PKG_DIR=/home/user/code/securedrop-log/dist/securedrop-log-0.0.4.tar.gz make securedrop-log
```