### PR TITLE
Use shallow clones for securedrop-workstation-dev-rpm-packages-lfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ common-steps:
     run:
       name: Commit workstation rpms for deployment to yum-test.securedrop.org
       command: |
-        git clone git@github.com:freedomofpress/securedrop-workstation-dev-rpm-packages-lfs.git
+        git clone --depth=1 git@github.com:freedomofpress/securedrop-workstation-dev-rpm-packages-lfs.git
         cd securedrop-workstation-dev-rpm-packages-lfs
 
         git config user.email "securedrop@freedom.press"


### PR DESCRIPTION
This will speed up the nightly cron job and reduce LFS bandwidth usage.