### PR TITLE
Bump kernel image version to 4.14.169

### DIFF
--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.169+buster) unstable; urgency=medium
+
+  * Update kernel version to 4.14.169
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 05 Feb 2020 15:38:14 -0800
+
 securedrop-workstation-grsec (4.14.158-1+buster) unstable; urgency=medium
 
   * Update kernel version to 4.14.158

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,11 +8,11 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 4.14.158
+upstream_version: 4.14.169
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
-Depends: linux-image-4.14.158-grsec-workstation,linux-headers-4.14.158-grsec-workstation,libelf-dev,paxctld
+Depends: linux-image-4.14.169-grsec-workstation,linux-headers-4.14.169-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -17,7 +17,7 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-GRSEC_VERSION='4.14.158-grsec-workstation'
+GRSEC_VERSION='4.14.169-grsec-workstation'
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus


### PR DESCRIPTION
Reusing the same config, updating to current stable in advance of SDW
pilot release.