### PR TITLE
Fixes #141 removes upstream virtualenv from image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 ---
 common-steps:
+  - &removevirtualenv
+    run:
+      name: Removes the upstream virtualenv from the original container image
+      command: sudo pip uninstall virtualenv -y
+
   - &installdeps
     run:
       name: Install Debian packaging dependencies
@@ -161,15 +166,15 @@ common-steps:
         echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
 
   - &setmetapackageversion
-      run:
-        name: Get metapackage version via distribution changelog
-        command: |
-          PLATFORM="$(lsb_release -sc)"
-          CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ${PKG_NAME}/debian/changelog-${PLATFORM} | head -n1)
-          export VERSION_TO_BUILD="$CURRENT_VERSION"
-          # Enable access to this env var in subsequent run steps
-          echo $VERSION_TO_BUILD > ~/packaging/sd_version
-          echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
+    run:
+      name: Get metapackage version via distribution changelog
+      command: |
+        PLATFORM="$(lsb_release -sc)"
+        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ${PKG_NAME}/debian/changelog-${PLATFORM} | head -n1)
+        export VERSION_TO_BUILD="$CURRENT_VERSION"
+        # Enable access to this env var in subsequent run steps
+        echo $VERSION_TO_BUILD > ~/packaging/sd_version
+        echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
 
   - &installgitlfs
     run:
@@ -250,6 +255,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredroplog
       - *getlatestreleasedversion
@@ -261,6 +267,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredroplog
       - *getnightlyversion
@@ -275,6 +282,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredropclient
       - *getlatestreleasedversion
@@ -286,6 +294,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredropclient
       - *getnightlyversion
@@ -300,6 +309,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredropproxy
       - *getlatestreleasedversion
@@ -311,6 +321,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredropproxy
       - *getnightlyversion
@@ -325,6 +336,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredropexport
       - *getlatestreleasedversion
@@ -336,6 +348,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *clonesecuredropexport
       - *getnightlyversion
@@ -350,6 +363,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *setsvsdispname
       - *setmetapackageversion
@@ -360,6 +374,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *installdeps
       - *setsvsdispname
       - *getnightlymetapackageversion
@@ -414,9 +429,9 @@ workflows:
       - build-buster-securedrop-workstation-grsec
       - make-dom0-rpm
 
-# Nightly jobs for each package are run in series to ensure there are no
-# conflicts or race conditions when committing deb packages to git-lfs.
-# Each nightly job requires the completion of the previous task in the sequence.
+  # Nightly jobs for each package are run in series to ensure there are no
+  # conflicts or race conditions when committing deb packages to git-lfs.
+  # Each nightly job requires the completion of the previous task in the sequence.
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
Now the upstream circleci Python image is coming with the latest
virtualenv, which is causing our builds to fail. This PR removes
the installation done via pip.

It also has YAML formatting fix for another job, and a comment set.
Done via YAML linter/formatter.

## How to test?

All Debian package builds in CI should be green.

After this PR is merged, any open PR on this repo should be rebased.