### PR TITLE
Updates securedrop-log to 0.1.1

### DIFF
--- a/securedrop-log/debian/changelog-buster
+++ b/securedrop-log/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-log (0.1.1+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 27 Feb 2020 08:25:27 -0800
+
 securedrop-log (0.1.0+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
Includes new logic to read "hostname" from the client VM sending the
logs, to reduce the configuration burden required to run the service.

Refs https://github.com/freedomofpress/securedrop-log/pull/16

## Testing
See full test plan in the SDW repo, and follow the steps there. Order of operations:

- [ ] Review and merge https://github.com/freedomofpress/securedrop-workstation/pull/487
- [x] Review and merge https://github.com/freedomofpress/securedrop-log/pull/16
- [ ] Review and merge https://github.com/freedomofpress/securedrop-debian-packaging/pull/150 (this PR)