### PR TITLE
securedrop-workstation-svs-disp and securedrop-export 0.2.2

### DIFF
--- a/scripts/update-changelog
+++ b/scripts/update-changelog
@@ -11,8 +11,8 @@ TOPLEVEL="$(git rev-parse --show-toplevel)"
 # These env vars are only required when updating changelogs,
 # otherwise the developer must edit the fields by hand, lest
 # they commit "user@localhost" entries.
-DEBEMAIL=${DEBEMAIL:-"securedrop@freedom.press"}
-DEBFULLNAME=${DEBFULLNAME:-"SecureDrop Team"}
+export DEBEMAIL=${DEBEMAIL:-"securedrop@freedom.press"}
+export DEBFULLNAME=${DEBFULLNAME:-"SecureDrop Team"}
 
 # Determine which package we want to update the changelog for.
 # As with the other tools, we'll support the PKG_NAME env var.

--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-export (0.2.2+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 20 Mar 2020 12:46:44 -0400
+
 securedrop-export (0.2.1+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-workstation-svs-disp/debian/changelog-buster
+++ b/securedrop-workstation-svs-disp/debian/changelog-buster
@@ -2,7 +2,7 @@ securedrop-workstation-svs-disp (0.2.2+buster) unstable; urgency=medium
 
   * Fix mime type handling for desktop files
 
- -- SecureDrop Team <user@localhost>  Fri, 20 Mar 2020 10:43:41 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 20 Mar 2020 10:43:41 -0400
 
 securedrop-workstation-svs-disp (0.2.1+buster) unstable; urgency=medium
 

--- a/securedrop-workstation-svs-disp/debian/changelog-buster
+++ b/securedrop-workstation-svs-disp/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-svs-disp (0.2.2+buster) unstable; urgency=medium
+
+  * Fix mime type handling for desktop files
+
+ -- SecureDrop Team <user@localhost>  Fri, 20 Mar 2020 10:43:41 -0400
+
 securedrop-workstation-svs-disp (0.2.1+buster) unstable; urgency=medium
 
   * Fix mime type handling for plaintext files

--- a/securedrop-workstation-svs-disp/mimeapps.list
+++ b/securedrop-workstation-svs-disp/mimeapps.list
@@ -11,6 +11,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document=libreoff
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-base.desktop
 application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-base.desktop
 application/pdf=org.gnome.Evince.desktop
+application/x-desktop=org.gnome.gedit.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop
 audio/x-wav=audacious.desktop


### PR DESCRIPTION
### Description
Towards https://github.com/freedomofpress/securedrop-client/issues/961
* Update mimeapps.list for securedrop-export and securedrop-workstation-svs-disp
* Update securedrop-export to 0.2.2
* Update to securedrop-workstation-svs-disp 0.2.2

### Test Plan 

see https://github.com/freedomofpress/securedrop-workstation/pull/501