### PR TITLE
ci: check that deb build process is reproducible after wheels and tarball are generated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,29 @@ common-steps:
         make $PKG_NAME
         ls ~/debbuild/packaging/*.deb
 
+  - &builddebianpackagefromexistingtarball
+    run:
+      name: Build debian package from committed tarball
+      command: |
+        export PKG_PATH=~/project/tarballs/$PKG_NAME-$PKG_VERSION.tar.gz
+
+        # Every tarball should be signed
+        gpg --import ~/project/pubkeys/release_key.pub
+        gpg --verify $PKG_PATH.asc
+
+        # Build debian package
+        make $PKG_NAME
+        export PKG_HASH_1=$(shasum -a 256 ~/debbuild/packaging/$PKG_NAME*.deb | awk '{print $1}')
+        echo $PKG_HASH_1
+
+        # Build debian package again
+        make $PKG_NAME
+        export PKG_HASH_2=$(shasum -a 256 ~/debbuild/packaging/$PKG_NAME*.deb | awk '{print $1}')
+        echo $PKG_HASH_2
+
+        # Fail build if hashes aren’t equal
+        python -c "import os, sys; sys.exit(os.environ['PKG_HASH_1'] != os.environ['PKG_HASH_2'])"
+
   - &addsshkeys
     add_ssh_keys:
       fingerprints:
@@ -457,6 +480,47 @@ jobs:
       - *setmetapackageversion
       - *builddebianpackage
 
+  reproducibility-checks:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *removevirtualenv
+      - *installdeps
+      - run: git lfs pull
+      - run:
+          name: Test build process reproducibility on latest securedrop-client tarball
+          command: |
+            export TARBALL=$(ls ~/project/tarballs/securedrop-client-*.tar.gz)
+            echo ${TARBALL%.tar.gz} | awk -F "-" '{ print $3 }' > ~/sd_version
+            echo 'export PKG_NAME=securedrop-client' >> $BASH_ENV
+            echo 'export PKG_VERSION=$(cat ~/sd_version)' >> $BASH_ENV
+      - *builddebianpackagefromexistingtarball
+      - run:
+          name: Test build process reproducibility on latest securedrop-proxy tarball
+          command: |
+            export TARBALL=$(ls ~/project/tarballs/securedrop-proxy-*.tar.gz)
+            echo ${TARBALL%.tar.gz} | awk -F "-" '{ print $3 }' > ~/sd_version
+            echo 'export PKG_NAME=securedrop-proxy' >> $BASH_ENV
+            echo 'export PKG_VERSION=$(cat ~/sd_version)' >> $BASH_ENV
+      - *builddebianpackagefromexistingtarball
+      - run:
+          name: Test build process reproducibility on latest securedrop-log tarball
+          command: |
+            export TARBALL=$(ls ~/project/tarballs/securedrop-log-*.tar.gz)
+            echo ${TARBALL%.tar.gz} | awk -F "-" '{ print $3 }' > ~/sd_version
+            echo 'export PKG_NAME=securedrop-log' >> $BASH_ENV
+            echo 'export PKG_VERSION=$(cat ~/sd_version)' >> $BASH_ENV
+      - *builddebianpackagefromexistingtarball
+      - run:
+          name: Test build process reproducibility on latest securedrop-export tarball
+          command: |
+            export TARBALL=$(ls ~/project/tarballs/securedrop-export-*.tar.gz)
+            echo ${TARBALL%.tar.gz} | awk -F "-" '{ print $3 }' > ~/sd_version
+            echo 'export PKG_NAME=securedrop-export' >> $BASH_ENV
+            echo 'export PKG_VERSION=$(cat ~/sd_version)' >> $BASH_ENV
+      - *builddebianpackagefromexistingtarball
+
 workflows:
   build-packages:
     jobs:
@@ -470,6 +534,7 @@ workflows:
       - build-buster-securedrop-workstation-config
       - build-buster-securedrop-keyring
       - make-dom0-rpm
+      - reproducibility-checks
 
   # Nightly jobs for each package are run in series to ensure there are no
   # conflicts or race conditions when committing deb packages to git-lfs.


### PR DESCRIPTION
After the tarball and wheels are generated, the deb package build
process should thereafter be reproducible. This PR adds a CI check for `securedrop-log`, `securedrop-client`, `securedrop-export`, `securedrop-proxy` to verify that is indeed the case (this was a manual step from https://github.com/freedomofpress/securedrop-workstation/wiki/Workstation-Beta-Acceptance-Tests#packages). 

I'm putting it in a job in CI as the hashes of the built deb are now printed in the CI build output and they should match the deployed packages. This can be used to cross-check with the build logs in the future (indeed, we could adapt this job to run in the LFS repo we use to commit built debs to check the built deb matches the hash of the package built in CI but I'm leaving that for another day). 