### PR TITLE
Adds gnome-disk-utility to dependencies of securedrop-export package

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -92,4 +92,9 @@ export SOURCE_DATE_EPOCH=`dpkg-parsechangelog -STimestamp`
 dpkg-buildpackage -us -uc
 
 # Tell the user the path of the files buillt
-echo "Find the .deb and other build files at $TOP_BUILDDIR/$PKG_NAME"
+pkg_path="$(find "$TOP_BUILDDIR" -type f -iname "${PKG_NAME}_${PKG_VERSION}*.deb" | head -n1)"
+if [[ -f "$pkg_path" ]]; then
+    echo "Package location: $pkg_path"
+else
+    echo "Could not find package, look in $TOP_BUILDDIR"
+fi

--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-export (0.2.3+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 27 Mar 2020 17:26:30 -0400
+
 securedrop-export (0.2.2+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-export/debian/control
+++ b/securedrop-export/debian/control
@@ -10,7 +10,7 @@ X-Python-3-Version: >= 3.5
 
 Package: securedrop-export
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, task-print-server, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv
+Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, task-print-server, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to 
  export submissions from the client to external storage, via the sd-export 


### PR DESCRIPTION
Towards freedomofpress/securedrop-workstation#511

Should be reviewed as part of https://github.com/freedomofpress/securedrop-workstation/pull/515, test plan in https://github.com/freedomofpress/securedrop-workstation/pull/515