### PR TITLE
securedrop-log build: add `--ignore-installed` and `--no-deps`

### DIFF
--- a/securedrop-log/debian/rules
+++ b/securedrop-log/debian/rules
@@ -1,7 +1,17 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv --python /usr/bin/python3 --setuptools --extra-pip-arg "--no-deps" --index-url https://pypi.securedrop.org/simple --requirements build-requirements.txt
+	dh $@ --with python-virtualenv
+
+override_dh_virtualenv:
+	dh_virtualenv \
+		--python /usr/bin/python3 \
+		--setuptools \
+		--index-url https://pypi.securedrop.org/simple \
+		--extra-pip-arg "--ignore-installed" \
+		--extra-pip-arg "--no-deps" \
+		--extra-pip-arg "--no-cache-dir" \
+		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete


### PR DESCRIPTION
Now that securedrop-log does have requirements, adding these two options that we are using for the other packages in this repository, see commit message for more details

## Suggested test plan

- [ ] Ensure that securedrop-log build passes in CI
- [ ] Ensure that adding these options makes sense