### PR TITLE
Prevent use of pip's PEP 517 build process

### DIFF
--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -12,6 +12,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--no-use-pep517" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -11,6 +11,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--no-use-pep517" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:

--- a/securedrop-log/debian/rules
+++ b/securedrop-log/debian/rules
@@ -11,6 +11,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--no-use-pep517" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:
@@ -18,4 +19,3 @@ override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
 	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
 	dh_strip_nondeterminism $@
-

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -11,6 +11,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
+		--extra-pip-arg "--no-use-pep517" \
 		--requirements build-requirements.txt
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
When `pyproject.toml` is added to projects (to support black and isort), pip changes its build processing, requiring downloads of isolated copies of `setuptools` and `wheel`. To avoid having to maintain those in our PyPI index, we can tell pip to not switch to PEP 517 mode.

## Testing

- Check out the `no-use-pep517` branch in this repo.
- Switch your `securedrop-client` repo to the `add-black-isort` branch, run `python setup.py sdist` for it, then rebuild the Debian package for it. It should complete without error. 
