### PR TITLE
Tweak paxctld logic in kernel metapackage

### DIFF
--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.186+buster1) unstable; urgency=medium
+
+  * Starts paxctld before dkms autoinstall step in postinst
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 16 Jul 2020 12:11:13 -0700
+
 securedrop-workstation-grsec (4.14.186+buster) unstable; urgency=medium
 
   * Update kernel version to 4.14.186

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -33,15 +33,18 @@ start_paxctld() {
     if [ -f "$paxctld_config" ]; then
         systemctl enable paxctld
         systemctl restart paxctld
+        # Wait just a moment while flag are re-applied
+        sleep 1
     fi
 }
 
 case "$1" in
     configure)
+    # Ensure pax flags are set prior to running dkms & grub
+    start_paxctld
     # DKMS autoinstall the qubes kernel modules
     dkms autoinstall $GRSEC_VERSION
     set_grub_default
-    start_paxctld
     update-grub
     ;;
 


### PR DESCRIPTION
Prior to building the kernel modules via dkms, let's make sure that paxctld is up and running, and all flags have been applied. Otherwise, a lack of exempting flag could cause the module build to fail.

Related to https://github.com/freedomofpress/securedrop-workstation/issues/590