### PR TITLE
support building projects with a requirments dir

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -69,7 +69,7 @@ if [[ "${PKG_NAME}" =~ ^(securedrop-client|securedrop-proxy|securedrop-export|se
     cd "$TOP_BUILDDIR/$PKG_NAME/"
 
     # Verify all the hashes from the verified sha256sums.txt
-    $CUR_DIR/scripts/verify-hashes $CUR_DIR/sha256sums.txt ./build-requirements.txt
+    $CUR_DIR/scripts/verify-hashes $CUR_DIR/sha256sums.txt
 
     echo "All hashes verified."
 else

--- a/scripts/update-requirements
+++ b/scripts/update-requirements
@@ -12,22 +12,23 @@ from pprint import pprint
 
 def main():
     PKG_DIR = os.environ["PKG_DIR"]
+
     if not PKG_DIR:
         print("Set PKG_DIR of the project")
         sys.exit(1)
 
-    input_requirements_path = os.path.join(
-        PKG_DIR, "requirements.txt")
+    requirements_file = os.path.join(PKG_DIR, "requirements.txt")
+    if not os.path.exists(requirements_file):
+        requirements_file = os.path.join(PKG_DIR, "requirements", "requirements.txt")
+        if not os.path.exists(requirements_file):
+            print("Cannot find requirements.txt")
+            sys.exit(1)
 
     output_requirements_path = os.path.join(
         PKG_DIR, "build-requirements.txt")
 
-    if not os.path.exists(input_requirements_path):
-        print("Missing {0}.".format(input_requirements_path))
-        sys.exit(1)
-
     # First remove index line and any PyQt or sip dependency
-    cleaned_lines = cleanup(input_requirements_path)
+    cleaned_lines = cleanup(requirements_file)
 
     verify_sha256sums_file()
 

--- a/scripts/verify-hashes
+++ b/scripts/verify-hashes
@@ -3,9 +3,16 @@
 import os
 import sys
 
-if len(sys.argv) != 3:
-    print("Usage: ./scripts/verify-hashes sha256sums.txt requirements.txt")
+if len(sys.argv) != 2:
+    print("Usage: ./scripts/verify-hashes path/to/sha256sums.txt")
     sys.exit(1)
+
+requirements_file = "requirements.txt"
+if not os.path.exists(requirements_file):
+    requirements_file = "requirements/requirements.txt"
+    if not os.path.exists(requirements_file):
+        print("Cannot find requirements.txt")
+        sys.exit(1)
 
 # This is the already gpg signed and verified data
 sha256sum_data = {}
@@ -24,7 +31,7 @@ for line in data:
 
 # Now read the requirements.txt file
 lines = []
-with open(sys.argv[2]) as fobj:
+with open(requirements_file) as fobj:
     lines = fobj.readlines()
 
 # Now we want to verify that for each dependency in the project

--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -13,7 +13,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
 		--extra-pip-arg "--no-use-pep517" \
-		--requirements build-requirements.txt
+		--requirements requirements/build-requirements.txt
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete


### PR DESCRIPTION
# Description

Support building packages for projects that use a requirements directory

# Test Plan

1. Checkout `move-req-files` client branch (see https://github.com/freedomofpress/securedrop-client/pull/1128)
- [ ] Verify that you can build a client debian package when the client uses a requirements directory