### PR TITLE
Builds source tarballs dynamically

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -27,6 +27,8 @@ TOP_BUILDDIR="$HOME/debbuild/packaging"
 mkdir -p "$TOP_BUILDDIR"
 rm -rf "${TOP_BUILDDIR:?}/${PKG_NAME}"
 mkdir -p "${TOP_BUILDDIR}/${PKG_NAME}"
+# Move changelog into place (we have separate changelogs for each platform)
+PLATFORM="$(lsb_release -sc)"
 
 # Validate required args.
 if [[ -z "${PKG_NAME:-}" ]]; then
@@ -34,9 +36,23 @@ if [[ -z "${PKG_NAME:-}" ]]; then
     exit 1
 fi
 
+
+function find_latest_version() {
+    repo_url="https://github.com/freedomofpress/${PKG_NAME}/releases"
+    curl -s "$repo_url" \
+        | perl -nE '$_ =~ m#/releases/tag/(v?[\d\.]+)\"# and say $1' \
+        | head -n 1
+}
+
 if [[ -z "${PKG_VERSION:-}" ]]; then
-    echo "Set PKG_VERSION of the build";
-    exit 1
+    echo "PKG_VERSION not set, inferring from recent releases..."
+    PKG_VERSION="$(find_latest_version)"
+    if [[ -z "$PKG_VERSION" ]]; then
+        echo "Failed to infer version"
+        exit 1
+    else
+        echo "Using PKG_VERSION: $PKG_VERSION"
+    fi
 fi
 
 # Copy over the debian directory (including new changelog) from repo
@@ -80,8 +96,6 @@ fi
 
 printf "Building package '%s' from version '%s'...\\n" "$PKG_NAME" "$PKG_VERSION"
 
-# Move changelog into place (we have separate changelogs for each platform)
-PLATFORM="$(lsb_release -sc)"
 echo "$TOP_BUILDDIR/$PKG_NAME/"
 mv "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-$PLATFORM" "$TOP_BUILDDIR/$PKG_NAME/debian/changelog"
 

--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -58,14 +58,26 @@ fi
 # Copy over the debian directory (including new changelog) from repo
 cp -r "$CUR_DIR/$PKG_NAME/" "$TOP_BUILDDIR/"
 
+function build_source_tarball() {
+    repo_url="https://github.com/freedomofpress/${PKG_NAME}"
+    build_dir="/tmp/${PKG_NAME}"
+    rm -rf "$build_dir"
+    git clone "$repo_url" "$build_dir"
+    git -C "$build_dir" tag --verify "$PKG_VERSION" 1>&2
+    git -C "$build_dir" checkout "$PKG_VERSION" 1>&2
+    (cd "$build_dir" && python setup.py sdist 1>&2)
+    find "${build_dir}/dist/" | grep -P '\.tar.gz$' | head -n1
+}
+
 # If the package is contained in the list, it should be a python package. In
 # that case, we should extract tarball, and validate wheel hashes.
 if [[ "${PKG_NAME}" =~ ^(securedrop-client|securedrop-proxy|securedrop-export|securedrop-log)$ ]]; then
     echo "${PKG_NAME} is a Python package"
 
     if [[ -z "${PKG_PATH:-}" ]]; then
-        # Try to find tarball in a reasonable location
-        candidate_pkg_path="$(realpath "${CUR_DIR}/../${PKG_NAME}/dist/${PKG_NAME}-${PKG_VERSION}.tar.gz")"
+        # Build from source
+        echo "PKG_PATH not set, building from source (version $PKG_VERSION)..."
+        candidate_pkg_path="$(build_source_tarball)"
         if [[ -f "$candidate_pkg_path" ]]; then
             PKG_PATH="$candidate_pkg_path"
             echo "Found tarball at $PKG_PATH, override with PKG_PATH..."

--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -37,6 +37,7 @@ if [[ -z "${PKG_NAME:-}" ]]; then
 fi
 
 
+# Look up most recent release from GitHub repo
 function find_latest_version() {
     repo_url="https://github.com/freedomofpress/${PKG_NAME}/releases"
     curl -s "$repo_url" \
@@ -58,15 +59,46 @@ fi
 # Copy over the debian directory (including new changelog) from repo
 cp -r "$CUR_DIR/$PKG_NAME/" "$TOP_BUILDDIR/"
 
+# Ensures that a given git tag is signed with the prod release key
+# If "rc" is in the tag name, this will fail.
+function verify_git_tag() {
+    local d
+    local t
+    d="$1"
+    t="$2"
+    prod_fingerprint="22245C81E3BAEB4138B36061310F561200F4AD77"
+    git -C "$build_dir" tag --verify "$PKG_VERSION" 2>&1 \
+        | grep -q -F "using RSA key $prod_fingerprint"
+}
+
+# Dynamically generate a tarball, from the Python source code,
+# that is byte-for-byte reproducible. Infers timestamp
+# from the changelog, same as for the deb package.
 function build_source_tarball() {
     repo_url="https://github.com/freedomofpress/${PKG_NAME}"
     build_dir="/tmp/${PKG_NAME}"
     rm -rf "$build_dir"
     git clone "$repo_url" "$build_dir"
-    git -C "$build_dir" tag --verify "$PKG_VERSION" 1>&2
-    git -C "$build_dir" checkout "$PKG_VERSION" 1>&2
-    (cd "$build_dir" && python setup.py sdist 1>&2)
-    find "${build_dir}/dist/" | grep -P '\.tar.gz$' | head -n1
+
+    # Verify tag, using only the prod key
+    verify_git_tag "$build_dir" "$PKG_VERSION"
+
+    # Tag is verified, proceed with checkout
+    git -C "$build_dir" checkout "$PKG_VERSION"
+    (cd "$build_dir" && LC_ALL="C.UTF-8" python setup.py sdist)
+
+    # Initial tarball will contain timestamps from NOW, let's repack
+    # with timestamps from the changelog, which is static.
+    raw_tarball="$(find "${build_dir}/dist/" | grep -P '\.tar.gz$' | head -n1)"
+    dch_time="$(date "+%Y-%m-%d %H:%M:%S %z" -d@$(dpkg-parsechangelog --file $PKG_NAME/debian/changelog-$PLATFORM -STimestamp)) "
+    (cd "$build_dir" && tar -xzf "dist/$(basename $raw_tarball)")
+    tarball_basename="$(basename "$raw_tarball")"
+    # Repack with tar only, so env vars are respected
+    (cd "$build_dir" && tar -cf "${tarball_basename%.gz}" --mode=go=rX,u+rw,a-s --mtime="$dch_time" --sort=name --owner=root:0 --group=root:0 "${tarball_basename%.tar.gz}" 1>&2)
+    # Then gzip it separately, so we can pass args
+    (cd "$build_dir" && gzip --no-name "${tarball_basename%.gz}")
+    (cd "$build_dir" && mv "$tarball_basename" dist/)
+    echo "$raw_tarball"
 }
 
 # If the package is contained in the list, it should be a python package. In
@@ -77,7 +109,8 @@ if [[ "${PKG_NAME}" =~ ^(securedrop-client|securedrop-proxy|securedrop-export|se
     if [[ -z "${PKG_PATH:-}" ]]; then
         # Build from source
         echo "PKG_PATH not set, building from source (version $PKG_VERSION)..."
-        candidate_pkg_path="$(build_source_tarball)"
+        build_source_tarball
+        candidate_pkg_path="$(find /tmp/$PKG_NAME/dist -type f -iname '*.tar.gz')"
         if [[ -f "$candidate_pkg_path" ]]; then
             PKG_PATH="$candidate_pkg_path"
             echo "Found tarball at $PKG_PATH, override with PKG_PATH..."

--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -67,8 +67,11 @@ function verify_git_tag() {
     d="$1"
     t="$2"
     prod_fingerprint="22245C81E3BAEB4138B36061310F561200F4AD77"
-    git -C "$build_dir" tag --verify "$PKG_VERSION" 2>&1 \
-        | grep -q -F "using RSA key $prod_fingerprint"
+    if ! git -C "$build_dir" tag --verify "$PKG_VERSION" 2>&1 \
+        | grep -q -F "using RSA key $prod_fingerprint" ; then
+        echo "Failed to verify $PKG_VERSION, not signed with $prod_fingerprint" >&2
+        exit 2
+    fi
 }
 
 # Dynamically generate a tarball, from the Python source code,


### PR DESCRIPTION
Ready for review. For reference, see discussion in https://github.com/freedomofpress/securedrop-debian-packaging/issues/182#issuecomment-664709727

## Changes
Full backwards compatibility is retained, so the original invocation will work just fine:

```
PKG_VERSION=0.2.1 PKG_PATH=tarballs/securedrop-client-0.2.1.tar.gz make securedrop-client
```

There's now an optional, terser step to build a package, where the version defaults to the latest tag, and the tarball is generated dynamically from that tag:

```
make securedrop-client
```

Regardless of which method is used, the `.deb` file generated from it is byte-for-byte identical over multiple runs. In both cases, the timestamp information is pulled in from the package changelog. Ideally we'd be using SOURCE_DATE_EPOCH in all places to manage the timestamp info, but not all tools support it yet (particularly not 'python setup.py sdist'). Hopefully we'll see movement upstream soon, and then we can standardize on using SOURCE_DATE_EPOCH everywhere to control timestamps. 

It's possible we'll want to break out the logic that chains python-sdist -> git -> tar -> gz so we can reuse it elsewhere, but not doing that now. 

## Testing

### debs are reproducible
Regardless of how the tarball was generated, or even which was used, the resulting `.deb` file for a specific package version should be identical. Confirm that by running the following:

```
#!/bin/bash
set -e

results_dir=/tmp/test_results
rm -rf "$results_dir"
mkdir -p "$results_dir"

echo "Building from new dynamic logic"
make securedrop-client
cp /home/user/debbuild/packaging/securedrop-client_0.2.1+buster_all.deb "${results_dir}/dynamic.deb"

echo "Building from historical static tarball"
PKG_VERSION=0.2.1 PKG_PATH=tarballs/securedrop-client-0.2.1.tar.gz make securedrop-client
cp /home/user/debbuild/packaging/securedrop-client_0.2.1+buster_all.deb "${results_dir}/static.deb"

echo "Comparing results"
sha256sum ${results_dir}/*
diffoscope ${results_dir}/* && echo "SUCCESS: fully reproducible"
```

You should see output of `4b65f8a91f8555a2e0303ce2cdb97a58addddbc7a2e6d3567805b8aa0a0f4ed3`, with the "SUCCESS" message printed at the bottom.

### tarballs are reproducible

The tarballs are an _intermediate_ artifact in our build process. Let's confirm that if we build them dynamically from source, we're getting identical artifacts—which is a new feature introduced by this PR.

```
# Prepare a results dir
rm -rf /tmp/results
mkdir /tmp/results

# Use the new dynamic build logic
make securedrop-client
cp /tmp/securedrop-client/dist/*.tar.gz /tmp/results/1.tar.gz
rm -rf /tmp/securedrop-client

# Run it again
make securedrop-client
cp /tmp/securedrop-client/dist/*.tar.gz /tmp/results/2.tar.gz
rm -rf /tmp/securedrop-client

# Compare the results!
sha256sum /tmp/results/*.tar.gz
diffoscope /tmp/results/*.tar.gz && echo "SUCCESS: fully reproducible
```