### PR TITLE
Checks for u2mfn kernel module in metapackage

### DIFF
--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.186+buster2) unstable; urgency=medium
+
+  * Ensures u2mfn module is built via dkms, otherwise fails
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 26 Aug 2020 15:05:49 -0700
+
 securedrop-workstation-grsec (4.14.186+buster1) unstable; urgency=medium
 
   * Starts paxctld before dkms autoinstall step in postinst

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -17,7 +17,11 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+
+# When updating the kernel version, also check that the u2mfn version matches:
+# https://github.com/QubesOS/qubes-linux-utils/blob/release4.0/version
 GRSEC_VERSION='4.14.186-grsec-workstation'
+U2MFN_VERSION="4.0.30"
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus
@@ -38,12 +42,34 @@ start_paxctld() {
     fi
 }
 
+# Checks that the u2mfn kernel module was successfully built via dkms.
+verify_u2mfn_exists() {
+    ko_filepath="/usr/lib/modules/${GRSEC_VERSION}/updates/dkms/u2mfn.ko"
+    if ! test -f "$ko_filepath"; then
+        return 1
+    fi
+}
+
+# For reasons unknown, u2mfn may be missing. If not found, try to rebuild it,
+# otherwise we'll fail and require admin intervention.
+ensure_u2mfn_exists() {
+    if ! verify_u2mfn_exists ; then
+        dkms remove u2mfn -v "$U2MFN_VERSION" -k "$GRSEC_VERSION" || true
+        dkms autoinstall -k "$GRSEC_VERSION"
+        if ! verify_u2mfn_exists ; then
+            echo "ERROR: u2mfn kernel object is missing: $ko_filepath"
+            exit 1
+        fi
+    fi
+}
+
 case "$1" in
     configure)
-    # Ensure pax flags are set prior to running dkms & grub
+    # Ensure pax flags are set prior to running grub
     start_paxctld
-    # DKMS autoinstall the qubes kernel modules
-    dkms autoinstall $GRSEC_VERSION
+    # Rebuild u2mfn kernel module if missing
+    ensure_u2mfn_exists
+    # Force latest hardened kernel for next boot
     set_grub_default
     update-grub
     ;;


### PR DESCRIPTION
# Overview

The u2mfn kernel module is required for GUI operations in a VM. It should be built automatically via dkms, but that process can fail. We must report such errors up to the parent apt operation to notify users. The /etc/kernel/postinst.d/dkms hooks are run on installation of the linux-image-* packages, so we don't need an explicit call to dkms autoinstall (which fails silently) in the metapackage postinst.

Since we've observed VMs fail to build the u2mfn.ko dynamically in the past, let's try to recover in that situation, otherwise fail loudly.

Related issues:

* Closes https://github.com/freedomofpress/securedrop-debian-packaging/issues/184
* Closes https://github.com/freedomofpress/securedrop-workstation/issues/590

# Test plan
## Reproduce distorted GUI
In order to verify that changes here reliably resolve the garbled terminal problem, you'll need a candidate VM that exhibits the problem. That's easy enough to create:


```
# Clone an up-to-date SDW TemplateVM, so tests happen in an isolated VM
qvm-clone securedrop-workstation-buster sdw-kernel-test

# Open a terminal for the subsequent commands. Note that the terminal
# works, i.e. is not garbled!
qvm-run sdw-kernel-test gnome-terminal
```

In the domU terminal:

```
uname -r # should show '4.14.186-grsec-workstation'
sudo rm -v /usr/lib/modules/$(uname -r)/updates/dkms/u2mfn.ko
```

Now reboot the VM, and re-run `qvm-run sdw-kernel-test gnome-terminal`. The graphical window should be garbled, as shown in https://github.com/freedomofpress/securedrop-workstation/issues/590 . If it's not, stop testing here!

## Confirm resolution via new metapackage
Now we'll attempt to resolve the broken GUI via the new metapackage. Check out the new metapackage build logic locally from this branch, and run in your dev VM (e.g. `sd-dev`):

```
# Build the new package
PKG_VERSION=4.14.186+buster2 make securedrop-workstation-grsec
# Copy the new package to your test VM 'sdw-kernel-test'
# You may need to adjust tags or RPC policies in dom0 to allow this,
# e.g. 'qvm-tags sdw-kernel-test del sd-workstation' in dom0
qvm-copy /home/user/debbuild/packaging/securedrop-workstation-grsec_4.14.186+buster2_amd64.deb
```

Since the graphical terminal is unusable, we'll install the package via cli from dom0:


```
qvm-run -p sdw-kernel-test 'sudo dpkg -i ./QubesIncoming/sd-dev/securedrop-workstation-grsec_4.14.186+buster2_amd64.deb'
echo $? # should show '0'
```

You should see dkms output referencing the build. That's good! Reboot the VM again, and re-run `gnome-terminal`. The graphical display should work correctly. Finally, as a sanity check, run the following in `sdw-kernel-test`:

```
uname -r # should show '4.14.186-grsec-workstation', as before
aptitude show securedrop-workstation-grsec | grep Version # should show '4.14.186+buster2' is installed
sudo ls -1 /usr/lib/modules/$(uname -r)/updates/dkms/u2mfn.ko # should display the fullpath to the module
```

That's it. If all that works, we should be in a good position to proceed with building the metapackage and placing on apt-test.
