### PR TITLE
Adds script to generate tag message

### DIFF
--- a/scripts/generate-tag-message
+++ b/scripts/generate-tag-message
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Utility script to generate a signed tag for the packaging repo:
+#
+#   https://github.com/freedomofpress/securedrop-debian-packaging
+#
+# Collects "version" field from package changelogs and prepares a summary
+# commit message when incrementing the tag.
+set -e
+set -u
+set -o pipefail
+
+
+if [[ $# != 1 ]]; then
+    echo "Usage: $0 <version>"
+    packaging_curver="$(git tag | sort -V | tail -n1)"
+    echo "The most recent tag available is: $packaging_curver"
+    echo "You probably want to increment that with a new tag."
+    exit 1
+fi
+
+new_version="$1"
+printf 'securedrop-debian-packaging %s\n\n' "$new_version"
+# Inspect all changelogs, prepare a pretty list of packages & versions
+for pkg in securedrop-*; do
+    pkg_version="$(dpkg-parsechangelog -SVersion --file "${pkg}/debian/changelog-buster" | perl -npE 's/\+buster$//')"
+    printf '%s %s\n' "$pkg" "$pkg_version"
+done


### PR DESCRIPTION
When tagging the "securedrop-debian-packaging" repository, we include
a list of all package versions, to make reasoning about releases easier
down the road. Collecting this information manually is error-prone, so
let's provide a routine method of generating that info so it can easily
be pasted into a prompt for an annotated git tag, consistent with docs.