### PR TITLE
Enforce AppArmor profile in postinst for securedrop-client

### DIFF
--- a/securedrop-client/debian/postinst
+++ b/securedrop-client/debian/postinst
@@ -22,6 +22,7 @@ case "$1" in
     configure)
 
     update-desktop-database /usr/share/applications
+    aa-enforce /usr/bin/securedrop-client
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Packaging changes required for https://github.com/freedomofpress/securedrop-client/pull/1159/

Note that `aa-enforce` (and the postinst) command will fail on a kernel that doesn't have AppArmor support, which is the case with Qubes PVH kernels. We could guard against this through a conditional, if we plan on installing the client in other VMs (which sounds unlikely)
See TBD for testplan