### PR TITLE
Temporarily disable SecureDrop Client nightlies during pre-release QA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -548,10 +548,7 @@ workflows:
               only:
                 - main
     jobs:
-      - build-nightly-buster-securedrop-client
-      - build-nightly-buster-securedrop-proxy:
-          requires:
-            - build-nightly-buster-securedrop-client
+      - build-nightly-buster-securedrop-proxy
       - build-nightly-buster-securedrop-export:
           requires:
             - build-nightly-buster-securedrop-proxy


### PR DESCRIPTION
This will allow us to publish an RC without it getting clobbered by new commits into the `main` branch, so development of new features can continue while QA is underway.

## Status

Ready for review