### PR TITLE
Updated buster changelogs for securedrop-client, -export, -log, -proxy

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.3.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+ 
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Nov 2020 11:40:46 -0500
+
 securedrop-client (0.2.1+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-export (0.2.4+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Nov 2020 11:48:25 -0500
+
 securedrop-export (0.2.3+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-log/debian/changelog-buster
+++ b/securedrop-log/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-log (0.1.2+buster) unstable; urgency=medium
+
+  * see changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Nov 2020 11:34:25 -0500
+
 securedrop-log (0.1.1+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-proxy (0.3.1+buster) unstable; urgency=medium
+ 
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Nov 2020 11:10:17 -0500
+
 securedrop-proxy (0.3.0+buster) unstable; urgency=medium
 
   * See changelog.md 


### PR DESCRIPTION
Updates changelogs for non-metapackage packages required for 0.5.0 securedrop-workstation release.
