### PR TITLE
Revert "Temporarily disable nightlies during pre-release QA"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -548,7 +548,10 @@ workflows:
               only:
                 - main
     jobs:
-      - build-nightly-buster-securedrop-proxy
+      - build-nightly-buster-securedrop-client
+      - build-nightly-buster-securedrop-proxy:
+          requires:
+            - build-nightly-buster-securedrop-client
       - build-nightly-buster-securedrop-export:
           requires:
             - build-nightly-buster-securedrop-proxy


### PR DESCRIPTION
This reverts commit 3a9a3ffb9fea813652f126684e642f5398a02e43.

Now that https://github.com/freedomofpress/securedrop-client/pull/1188 is merged and 0.3.0 is released, we should re-enable client nighly builds