### PR TITLE
Bumps u2mfn version 4.0.30 -> 4.0.31

### DIFF
--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-grsec (4.14.186+buster3) unstable; urgency=medium
+
+  * Bumps u2mfn version 4.0.30 -> 4.0.31
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 17 Nov 2020 15:57:41 -0800
+
 securedrop-workstation-grsec (4.14.186+buster2) unstable; urgency=medium
 
   * Ensures u2mfn module is built via dkms, otherwise fails

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -12,6 +12,7 @@ upstream_version: 4.14.186
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
+Pre-Depends: qubes-kernel-vm-support (>=4.0.31)
 Depends: linux-image-4.14.186-grsec-workstation,linux-headers-4.14.186-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -21,7 +21,7 @@ set -e
 # When updating the kernel version, also check that the u2mfn version matches:
 # https://github.com/QubesOS/qubes-linux-utils/blob/release4.0/version
 GRSEC_VERSION='4.14.186-grsec-workstation'
-U2MFN_VERSION="4.0.30"
+U2MFN_VERSION="4.0.31"
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus


### PR DESCRIPTION
Tracking upstream changes so that clean installs continue to work.

Attempts to resolve https://github.com/freedomofpress/securedrop-workstation/issues/644 