### PR TITLE
Adds changelog for securedrop-client 0.4.0

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.4.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 10 Dec 2020 14:36:06 -0800
+
 securedrop-client (0.3.0+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
Updates buster changelog for `securedrop-client` package, refs https://github.com/freedomofpress/securedrop-client/issues/1189 . 

I'd previously included a signed tarball, following the documentation in the README. Build logs for that tarball can be found here: https://github.com/freedomofpress/build-logs/commit/1af4af92bbd1d975a5897140066f88cca06c2511 However, the CI checks were [failing the reproducibility tests](https://app.circleci.com/pipelines/github/freedomofpress/securedrop-debian-packaging/794/workflows/fc8d5a82-125c-4897-81a7-3ec669110113/jobs/6176). Since we have fully reproducible deb packages based on signed tags, I'm going to proceed with building from the 0.4.0 tag. 