### PR TITLE
Makes wheel builds reproducible, with tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,7 @@ jobs:
       - run:
           name: install test requirements and run tests
           command: |
+            make install-deps
             virtualenv .venv
             source .venv/bin/activate
             pip install -r test-requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,15 +281,15 @@ common-steps:
 version: 2.1
 jobs:
   tests:
-    docker:
-      - image: circleci/python:3.7-buster
+    machine:
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
       - run:
           name: install test requirements and run tests
           command: |
             make install-deps
-            virtualenv .venv
+            virtualenv -p python3 .venv
             source .venv/bin/activate
             pip install -r test-requirements.txt
             make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+tests/__pycache__/
 debhelper-build-stamp
 *.debhelper.log

--- a/Makefile
+++ b/Makefile
@@ -63,14 +63,7 @@ clean: ## Removes all non-version controlled packaging artifacts
 
 .PHONY: reprotest
 reprotest: ## Reproducibility test, currently only for wheels
-# The following config works for wheels:
-#   --variations "+environment, +build_path, +kernel, +aslr, +num_cpus, -time, +user_group, +fileordering, +domain_host, +home, +locales, +exec_path, +timezone, +umask" \
-# which is every reproducibility test *except* time, so we'll use the shorter syntax.
-# Messing with system time breaks most HTTPS GET actions.
-	reprotest -c "./scripts/build-sync-wheels -p $$HOME/securedrop-client --clobber" \
-		--vary "+all, -time, -locales, -kernel"\
-		. \
-		"localwheels/*.whl"
+	pytest -vvs tests/test_reproducible_wheels.py
 
 .PHONY: help
 help: ## Prints this message and exits

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,17 @@ test: ## Run test suite
 clean: ## Removes all non-version controlled packaging artifacts
 	rm -rf localwheels/*
 
+.PHONY: reprotest
+reprotest: ## Reproducibility test, currently only for wheels
+# The following config works for wheels:
+#   --variations "+environment, +build_path, +kernel, +aslr, +num_cpus, -time, +user_group, +fileordering, +domain_host, +home, +locales, +exec_path, +timezone, +umask" \
+# which is every reproducibility test *except* time, so we'll use the shorter syntax.
+# Messing with system time breaks most HTTPS GET actions.
+	reprotest -c "./scripts/build-sync-wheels -p $$HOME/securedrop-client --clobber" \
+		--vary "+all, -time, -locales" \
+		. \
+		"localwheels/*.whl"
+
 .PHONY: help
 help: ## Prints this message and exits
 	@printf "Makefile for building SecureDrop Workstation packages\n"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ reprotest: ## Reproducibility test, currently only for wheels
 # which is every reproducibility test *except* time, so we'll use the shorter syntax.
 # Messing with system time breaks most HTTPS GET actions.
 	reprotest -c "./scripts/build-sync-wheels -p $$HOME/securedrop-client --clobber" \
-		--vary "+all, -time, -locales" \
+		--vary "+all, -time, -locales, -kernel"\
 		. \
 		"localwheels/*.whl"
 

--- a/scripts/build-sync-wheels
+++ b/scripts/build-sync-wheels
@@ -2,11 +2,27 @@
 
 import os
 import sys
-import json
 import subprocess
 import tempfile
 import shutil
 import argparse
+
+
+# Set SOURCE_DATE_EPOCH to a predictable value. Using the first
+# commit to the SecureDrop project:
+#
+#   git show -s 62bbe590afd77a6af2dcaed46c93da6e0cf40951 --date=unix
+#
+# which yields 1309379017
+os.environ["SOURCE_DATE_EPOCH"] = "1309379017"
+
+# Force sane umask for reproducibility's sake.
+os.umask(0o022)
+
+# When building wheels, pip defaults to a safe dynamic tmpdir path.
+# Some shared objects include the path from build, so we must make
+# the path predictable across builds.
+WHEEL_BUILD_DIR = "/tmp/pip-wheel-build"
 
 
 def main():
@@ -19,6 +35,10 @@ def main():
     )
     parser.add_argument(
         "--cache", default="./localwheels", help="Final cache dir"
+    )
+    parser.add_argument(
+        "--clobber", action="store_true", default=False,
+        help="Whether to overwrite wheels and source tarballs",
     )
     args = parser.parse_args()
 
@@ -36,6 +56,11 @@ def main():
         print("requirements.txt missing at {0}.".format(req_path))
         sys.exit(3)
 
+    if os.path.exists(WHEEL_BUILD_DIR):
+        shutil.rmtree(WHEEL_BUILD_DIR)
+    else:
+        os.mkdir(WHEEL_BUILD_DIR)
+
     with tempfile.TemporaryDirectory() as tmpdir:
         # The --require-hashes option will be used by default if there are
         # hashes in the requirements.txt file. We specify it anyway to guard
@@ -46,9 +71,9 @@ def main():
             "--no-binary",
             ":all:",
             "--require-hashes",
-            "-d",
+            "--dest",
             tmpdir,
-            "-r",
+            "--requirement",
             req_path,
         ]
         subprocess.check_call(cmd)
@@ -58,11 +83,15 @@ def main():
             "wheel",
             "--no-binary",
             ":all:",
-            "-f",
+            "--find-links",
             tmpdir,
-            "-w",
+            "--progress-bar",
+            "pretty",
+            "--wheel-dir",
             tmpdir,
-            "-r",
+            "--build",
+            WHEEL_BUILD_DIR,
+            "--requirement",
             req_path,
         ]
         subprocess.check_call(cmd)
@@ -76,7 +105,8 @@ def main():
             if name == "requirements.txt":  # We don't need this in cache
                 continue
             if name in cachenames:  # Means all ready in our cache
-                continue
+                if not args.clobber:
+                    continue
 
             # Else copy to cache
             filepath = os.path.join(tmpdir, name)

--- a/scripts/build-sync-wheels
+++ b/scripts/build-sync-wheels
@@ -31,7 +31,7 @@ def main():
     )
     parser.add_argument(
         "-p",
-        help="Points to the project dirctory",
+        help="Points to the project directory",
     )
     parser.add_argument(
         "--cache", default="./localwheels", help="Final cache dir"
@@ -42,9 +42,16 @@ def main():
     )
     args = parser.parse_args()
 
-    if not os.path.exists(args.p):
-        print("Project directory missing {0}.".format(args.p))
-        sys.exit(1)
+    if args.p.startswith("https://"):
+        git_clone_directory = tempfile.mkdtemp(prefix=os.path.basename(args.p))
+        cmd = f"git clone {args.p} {git_clone_directory}".split()
+        subprocess.check_call(cmd)
+        args.p = git_clone_directory
+    else:
+        git_clone_directory = ""
+        if not os.path.exists(args.p):
+            print("Project directory missing {0}.".format(args.p))
+            sys.exit(1)
 
     # Try requirements.txt in the repo root, otherwise try requirements/requirements.txt
     req_path = os.path.join(args.p, "requirements.txt")
@@ -112,6 +119,9 @@ def main():
             filepath = os.path.join(tmpdir, name)
             shutil.copy(filepath, args.cache, follow_symlinks=True)
             print("Copying {0} to cache {1}".format(name, args.cache))
+
+    if git_clone_directory:
+        shutil.rmtree(git_clone_directory)
 
 
 if __name__ == "__main__":

--- a/scripts/install-deps
+++ b/scripts/install-deps
@@ -15,7 +15,8 @@ sudo apt-get install  \
     libssl-dev \
     python3-all \
     python3-pip \
-    python3-setuptools
+    python3-setuptools \
+    reprotest
 
 
 # Inspect the wheel files present locally. If repo was cloned

--- a/scripts/install-deps
+++ b/scripts/install-deps
@@ -2,6 +2,11 @@
 # Installs required dependencies for building SecureDrop Worsktation packages.
 # Assumes a Debian 10 machine, ideally a Qubes AppVM.
 
+# If running in CI, we need to add the Ubuntu Bionic repo to download dh-virtualenv
+if [[ -v CIRCLE_BUILD_URL ]]; then
+  echo "deb http://archive.ubuntu.com/ubuntu/ bionic universe" | sudo tee -a /etc/apt/sources.list
+fi
+
 sudo apt-get update
 sudo apt-get install  \
     build-essential \

--- a/tests/test_reproducible_wheels.py
+++ b/tests/test_reproducible_wheels.py
@@ -1,0 +1,43 @@
+import pytest
+import subprocess
+
+
+# These are the SDW repositories that we build wheels for.
+REPOS_WITH_WHEELS = [
+    "securedrop-client",
+    # "securedrop-log",
+    # "securedrop-proxy",
+]
+
+
+def get_repo_root():
+    cmd = "git rev-parse --show-toplevel".split()
+    top_level = subprocess.check_output(cmd).decode("utf-8").rstrip()
+    return top_level
+
+
+@pytest.mark.parametrize("repo_name", REPOS_WITH_WHEELS)
+def test_wheel_builds_are_reproducible(repo_name):
+    """
+    Uses 'reprotest' to confirm that the wheel build process, per repo,
+    is deterministic, i.e. all .whl files are created with the same checksum
+    across multiple builds.
+
+    Explanations of the excluded reproducibility checks:
+
+      * time: breaks HTTPS, so pip calls fail
+      * locales: some locales fail, would be nice to fix, but low priority
+      * kernel: x86_64 is the supported architecure, we don't ship others
+    """
+    repo_url = f"https://github.com/freedomofpress/{repo_name}"
+    cmd = [
+        "reprotest",
+        "-c",
+        f"./scripts/build-sync-wheels -p {repo_url} --clobber",
+        "--vary",
+        "+all, -time, -locales, -kernel",
+        ".",
+        "localwheels/*.whl",
+    ]
+    repo_root = get_repo_root()
+    subprocess.check_call(cmd, cwd=repo_root)

--- a/tests/test_reproducible_wheels.py
+++ b/tests/test_reproducible_wheels.py
@@ -5,8 +5,8 @@ import subprocess
 # These are the SDW repositories that we build wheels for.
 REPOS_WITH_WHEELS = [
     "securedrop-client",
-    # "securedrop-log",
-    # "securedrop-proxy",
+    "securedrop-log",
+    "securedrop-proxy",
 ]
 
 


### PR DESCRIPTION
### Overview
Refs #196

Makes two changes to our existing wheel build process:

  1. Setting SOURCE_DATE_EPOCH env var
  2. Setting a hardcoded dir path for all wheels builds

With those changes, the `./scripts/build-sync-wheels` script builds wheels that are byte-for-byte reproducible. I also included a test-only Makefile target that was handy during development. It's not yet ready for CI, because I'm seeing the platform vary in the reprotest build environment. More input appreciated if anyone can resolve that problem, see initial report in https://github.com/freedomofpress/securedrop-debian-packaging/issues/196#issuecomment-733417904

### Testing 
First, it's helpful to observe the wheel checksums changing over multiple builds, to understand the problem we're trying to solve.

1. Check out a new branch, _based on main_, rather than this feature branch.
2. Run `git rm localwheels/*.whl` and commit.
3. Run `./build-sync-wheels -p ../securedrop-client`, updating the dirpath as necessary. Commit the results.
4. Run `git rm localwheels/*.whl`, but don't commit the results.
5.  Run `./build-sync-wheels -p ../securedrop-client` again, and commit the results.
6. Run `git show --name-status` and confirm that many of the `localwheels/*.whl` files changed. 

That's a convoluted workflow because the build-sync-wheels script will politely avoid overwriting wheel files that already exist. In this PR, a `--clobber` flag is added to the script to force overwrites, making comparison easier.

OK, now let's verify the new behavior! 

1. Check out a new branch, _based on this branch_. Note that the `localwheels/*.whl` files are identical to those on the main branch.
2. Run `./build-sync-wheels --clobber -p ../securedrop-client`, updating the dirpath as necessary. Commit the results.
3. Run `./build-sync-wheels --clobber -p ../securedrop-client` again 
4. Run `git status`, confirm that there are no local modifications. The wheels were fetched, but identical. 

That's about it. Eventually, I'd love to drop the requirement that we store the wheels in version control, separately from the deb packages that contain them. But the work here is a step in that direction: once we have reproducible wheels, we can work on skipping artifact storage as long as the final output is deterministic. 