### PR TITLE
Update path to copy workstation debs for nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ common-steps:
         git config user.name "sdcibot"
 
         # Copy built debian packages to the relevant workstation repo and git push.
-        cp ~/debbuild/packaging/*.deb ./workstation/${PLATFORM}/
+        cp ~/project/build/debbuild/packaging/*.deb ./workstation/${PLATFORM}/
         git add workstation/${PLATFORM}/*.deb
         git commit -m "Automated SecureDrop workstation build"
         git push origin main


### PR DESCRIPTION
Fixes #216 

See https://app.circleci.com/pipelines/github/freedomofpress/securedrop-debian-packaging?branch=please-build-nightlies for successful build using this commit