### PR TITLE
Fixes typo in config 0.1.6 changelog

### DIFF
--- a/securedrop-workstation-config/debian/changelog-buster
+++ b/securedrop-workstation-config/debian/changelog-buster
@@ -2,7 +2,7 @@ securedrop-workstation-config (0.1.6+buster) unstable; urgency=medium
 
   * Bugfix in .desktop file syntax; improved Fail Closed behavior
 
--- SecureDrop Team <securedrop@freedom.press>  Tue, 02 Mar 2021 15:00:00 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 02 Mar 2021 15:00:00 -0400
 
 securedrop-workstation-config (0.1.5+buster) unstable; urgency=medium
 


### PR DESCRIPTION
When running `./scripts/generate-tag-message`, warnings were emitted
about a badly formatted header line:

    dpkg-parsechangelog: warning: securedrop-workstation-config/debian/changelog-buster(l5): badly formatted heading line
    LINE: -- SecureDrop Team <securedrop@freedom.press>  Tue, 02 Mar 2021 15:00:00 -0400
    dpkg-parsechangelog: warning: securedrop-workstation-config/debian/changelog-buster(l7): found start of entry where expected more change data or trailer
    LINE: securedrop-workstation-config (0.1.5+buster) unstable; urgency=medium
    dpkg-parsechangelog: warning: securedrop-workstation-config/debian/changelog-buster(l7): found end of file where expected more change data or trailer
