### PR TITLE
Add .desktop file linting to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,15 +258,16 @@ common-steps:
 
 version: 2.1
 jobs:
-  tests:
+  lint-and-test:
     machine:
       image: ubuntu-2004:202010-01
     steps:
       - checkout
       - run:
-          name: install test requirements and run tests
+          name: install test requirements, run linters, and run tests
           command: |
             make install-deps
+            make lint-desktop-files
             virtualenv -p python3 .venv
             source .venv/bin/activate
             pip install -r test-requirements.txt
@@ -494,7 +495,7 @@ jobs:
 workflows:
   build-packages:
     jobs:
-      - tests
+      - lint-and-test
       - reprotest-wheels
       - reprotest-debs
       - build-buster-securedrop-client


### PR DESCRIPTION
# Description

To catch syntax errors like the one fixed in #221, this PR adds the existing `lint-deskop-files` Makefile target to CI. I've opted to combine it with the test job for now, since the `install-deps` step is pretty heavy and it's only this one linter for now; would suggest we reorganize if/when we add more linters.

# Status

Ready for review