### PR TITLE
Add m4a (audio/mp4) to allow-list for sd-viewer

### DIFF
--- a/securedrop-workstation-config/mimeapps.list.sd-viewer
+++ b/securedrop-workstation-config/mimeapps.list.sd-viewer
@@ -12,6 +12,7 @@ application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-ba
 application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-base.desktop
 application/pdf=org.gnome.Evince.desktop
 application/x-desktop=org.gnome.gedit.desktop
+audio/mp4=audacious.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop
 audio/x-wav=audacious.desktop


### PR DESCRIPTION
M4A files use a different MIME type than MP3 and therefore currently will just silently exit out.

Resolves https://github.com/freedomofpress/securedrop-workstation/issues/664

# Test plan

1. Download https://filesamples.com/samples/audio/m4a/sample1.m4a and upload to your SD instance
2. Sync with SD Client on Qubes and attempt to play
3. [x] Observe failure
4. Build package from this branch & install in `sd-large-buster-template`; shut down template
5. Repeat step 2
6. [x] ~Profit!!!1~ Observe that M4A file now plays as expected
7. Review https://github.com/freedomofpress/securedrop-workstation/pull/665 for updated test