### PR TITLE
add changelog for securedrop-client 0.4.1

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.4.1+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 17 Mar 2021 11:20:12 -0700
+
 securedrop-client (0.4.0+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
Updates buster changelog for `securedrop-client` package, refs https://github.com/freedomofpress/securedrop-client/issues/1221 so that @emkll can create a tag and sign it in the client repo.