### PR TITLE
add changelog for securedrop-export 0.2.5

### DIFF
--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-export (0.2.5+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 17 Mar 2021 11:24:08 -0700
+
 securedrop-export (0.2.4+buster) unstable; urgency=medium
 
   * See changelog.md 


### PR DESCRIPTION
Updates buster changelog for `securedrop-export` package, refs https://github.com/freedomofpress/securedrop-client/issues/1221 so that @emkll can create a tag and sign it in the export repo.