### PR TITLE
Fix builds from prod tags

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -83,7 +83,7 @@ function build_source_tarball() {
     rm -rf "$build_dir"
     git clone "$repo_url" "$build_dir"
 
-    if [[ -n "$PKG_GITREF" ]]; then
+    if [[ -n "${PKG_GITREF:-}" ]]; then
         # Can't expect a prod sig on a gitref, likely a feature branch
         git -C "$build_dir" checkout "$PKG_GITREF"
     else


### PR DESCRIPTION
Since we use "set -u" inside the build script, we must test for
definedness of the PKG_GITREF variable. Let's set that to an empty
string by default, which satisfies "set -u".

Closes #228.