### PR TITLE
Adds nightly builds for securedrop-workstation-config metapackage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,19 @@ jobs:
       - *setmetapackageversion
       - *builddebianpackage
 
+  build-nightly-buster-securedrop-workstation-config:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *installdeps
+      - *setsdconfigname
+      - *getnightlymetapackageversion
+      - *updatedebianchangelog
+      - *builddebianpackage
+      - *addsshkeys
+      - *commitworkstationdebs
+
   build-buster-securedrop-keyring:
     docker:
       - image: circleci/python:3.7-buster
@@ -533,6 +546,9 @@ workflows:
       - build-nightly-buster-securedrop-workstation-svs-disp:
           requires:
             - build-nightly-buster-securedrop-log
+      - build-nightly-buster-securedrop-workstation-config:
+          requires:
+            - build-nightly-buster-securedrop-workstation-svs-disp
       # There is also a dom0 rpm build `build-nightly-dom0-rpm`
       # intended for staging environments but it is temporarily
       # disabled to enable pre-release QA of release candidate RPMs.


### PR DESCRIPTION
#### Test plan
- [ ] Adding a config package nightly build make sense 
- [ ] please-build-nightlies branch https://github.com/freedomofpress/securedrop-debian-packaging/compare/please-build-nightlies?expand=1 has built and pushed the package
- [ ] the "nightly" version of the package above is deployed in https://apt-test.freedom.press/pool/main/s/securedrop-workstation-config/