### PR TITLE
Adds build_path checks for deb pkg reprotest

### DIFF
--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -20,5 +20,6 @@ override_dh_virtualenv:
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
-	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
+	find ./debian/ -type f -name 'direct_url.json' -delete
+	find ./debian/ -type f -name 'RECORD' -delete
 	dh_strip_nondeterminism $@

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -19,5 +19,6 @@ override_dh_virtualenv:
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
-	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
+	find ./debian/ -type f -name 'direct_url.json' -delete
+	find ./debian/ -type f -name 'RECORD' -delete
 	dh_strip_nondeterminism $@

--- a/securedrop-log/debian/rules
+++ b/securedrop-log/debian/rules
@@ -19,5 +19,6 @@ override_dh_virtualenv:
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
-	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
+	find ./debian/ -type f -name 'direct_url.json' -delete
+	find ./debian/ -type f -name 'RECORD' -delete
 	dh_strip_nondeterminism $@

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -19,5 +19,6 @@ override_dh_virtualenv:
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
-	find -type f -name RECORD -exec sed -i -e '/.*\.pyc.*/d' {} +
+	find ./debian/ -type f -name 'direct_url.json' -delete
+	find ./debian/ -type f -name 'RECORD' -delete
 	dh_strip_nondeterminism $@

--- a/tests/test_reproducible_debian_packages.py
+++ b/tests/test_reproducible_debian_packages.py
@@ -41,7 +41,7 @@ def test_deb_builds_are_reproducible(pkg_name):
         "-c",
         f"make {pkg_name}",
         "--variations",
-        "-all, -kernel, +exec_path",
+        "-all, -kernel, +exec_path, +build_path",
         ".",
         f"build/debbuild/packaging/{pkg_name}*.deb",
     ]


### PR DESCRIPTION
In #231 we noticed that the filesystem path used to build the debian
packages was breaking reproducibility. That's due to the filepath being
recorded inside `direct_url.json`, as stipulated by PEP610.

Also relevant is PEP427, which describes the `RECORD` file for wheels.
Here we remove that file, as well, to ensure full reproducibility
regardless of path.

### Testing

To evaluate change in the problematic behavior reported in #231, clone this branch fresh in a few different locations, e.g. in DispVMs, and try rebuilding. Make sure that the absolute path of the repo is different between builds! The checksum of the .deb packages should be identical. 