### PR TITLE
Bumps workstation kernel to 4.14.240

### DIFF
--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,3 +1,10 @@
+securedrop-workstation-grsec (4.14.240+buster) unstable; urgency=medium
+
+  * Update kernel version to 4.14.240
+  * Bumps u2mfn version 4.0.31 -> 4.0.34
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 27 Jul 2021 10:28:20 -0400
+
 securedrop-workstation-grsec (4.14.186+buster3) unstable; urgency=medium
 
   * Bumps u2mfn version 4.0.30 -> 4.0.31

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -20,8 +20,8 @@ set -e
 
 # When updating the kernel version, also check that the u2mfn version matches:
 # https://github.com/QubesOS/qubes-linux-utils/blob/release4.0/version
-GRSEC_VERSION='4.14.186-grsec-workstation'
-U2MFN_VERSION="4.0.31"
+GRSEC_VERSION='4.14.240-grsec-workstation'
+U2MFN_VERSION="4.0.34"
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus


### PR DESCRIPTION
Includes a u2mfn version update, as well, which is required until Qubes
4.1 is final, when we can drop the u2mfn dependency entirely.