### PR TITLE
Bumps workstation kernel to 4.14.241

### DIFF
--- a/securedrop-workstation-grsec/debian/changelog-buster
+++ b/securedrop-workstation-grsec/debian/changelog-buster
@@ -1,9 +1,9 @@
-securedrop-workstation-grsec (4.14.240+buster) unstable; urgency=medium
+securedrop-workstation-grsec (4.14.241+buster) unstable; urgency=medium
 
-  * Update kernel version to 4.14.240
+  * Update kernel version to 4.14.241
   * Bumps u2mfn version 4.0.31 -> 4.0.34
 
- -- SecureDrop Team <securedrop@freedom.press>  Tue, 27 Jul 2021 10:28:20 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 04 Aug 2021 07:36:23 -0700
 
 securedrop-workstation-grsec (4.14.186+buster3) unstable; urgency=medium
 

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,12 +8,12 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 4.14.186
+upstream_version: 4.14.241
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
 Pre-Depends: qubes-kernel-vm-support (>=4.0.31)
-Depends: linux-image-4.14.186-grsec-workstation,linux-headers-4.14.186-grsec-workstation,libelf-dev,paxctld
+Depends: linux-image-4.14.241-grsec-workstation,linux-headers-4.14.241-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -20,7 +20,7 @@ set -e
 
 # When updating the kernel version, also check that the u2mfn version matches:
 # https://github.com/QubesOS/qubes-linux-utils/blob/release4.0/version
-GRSEC_VERSION='4.14.240-grsec-workstation'
+GRSEC_VERSION='4.14.241-grsec-workstation'
 U2MFN_VERSION="4.0.34"
 
 # Sets default grub boot parameter to the kernel version specified


### PR DESCRIPTION
The previous version, based on 4.14.240, did not work well in Qubes VMs.
After adjusting the config, rebuilt on an incidentally slightly newer
kernel version, and that artifact behaves well in VMs. Removing the 240
version from the changelog, since it was never shipped to prod.

Also updates the control file fields, which update was omitted in #255.