### PR TITLE
Update signing key fingerprint

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -66,7 +66,7 @@ function verify_git_tag() {
     local t
     d="$1"
     t="$2"
-    prod_fingerprint="22245C81E3BAEB4138B36061310F561200F4AD77"
+    prod_fingerprint="2359E6538C0613E652955E6C188EDD3B7B22E6A3"
     if ! git -C "$build_dir" tag --verify "$PKG_VERSION" 2>&1 \
         | grep -q -F "using RSA key $prod_fingerprint" ; then
         echo "Failed to verify $PKG_VERSION, not signed with $prod_fingerprint" >&2


### PR DESCRIPTION
See key rotation blog post for more information:
https://securedrop.org/news/why-we-are-rotating-the-securedrop-release-key/