### PR TITLE
Update proxy reqs path

### DIFF
--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -3,7 +3,10 @@
 %:
 	dh $@ --with python-virtualenv
 
+REQUIREMENTS_FILE=requirements/build-requirements.txt
+
 override_dh_virtualenv:
+	test -e $(REQUIREMENTS_FILE)
 	dh_virtualenv \
 		--python /usr/bin/python3 \
 		--setuptools \
@@ -14,7 +17,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
 		--extra-pip-arg "--no-use-pep517" \
-		--requirements build-requirements.txt
+		--requirements $(REQUIREMENTS_FILE)
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete


### PR DESCRIPTION
Recent nightlies of `securedrop-proxy` were broken, due to missing
imports [0]. In a recent PR [1], the requirements files within the
securedrop-proxy repo (and therefore tarball) were moved, and the
package build logic depends on those locations.

To my great surprise and disappoint, dh_virtualenv evidently will not
complain if a `--requirements` file does not exist. The build will be
called successful. That's unacceptable, so I've modified the
debian/rules file to test for existence as a workaround. If folks agree
this is a sane solution, we should update the rules files for the other
packages to match.

[0] https://github.com/freedomofpress/securedrop-proxy/issues/94
[1] https://github.com/freedomofpress/securedrop-proxy/pull/92

## Testing

To test, you can manually build a package with this change included. Or, we can simply rely on visual review, and observe tonight's nightlies unbreaking the problem on all existing dev/staging Workstation installs. I have a preference for the latter myself.