### PR TITLE
update paths for build reqs for various projects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ jobs:
       - *removevirtualenv
       - *installdeps
       - *clonesecuredropexport
-      - *getlatestreleasedversion
+      - *getnightlyversion
       - *makesourcetarball
       - *builddebianpackage
 

--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -3,7 +3,10 @@
 %:
 	dh $@ --with python-virtualenv
 
+REQUIREMENTS_FILE=requirements/build-requirements.txt
+
 override_dh_virtualenv:
+	test -e $(REQUIREMENTS_FILE)
 	dh_virtualenv \
 		--python /usr/bin/python3 \
 		--setuptools \
@@ -15,7 +18,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
 		--extra-pip-arg "--no-use-pep517" \
-		--requirements requirements/build-requirements.txt
+		--requirements $(REQUIREMENTS_FILE)
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -3,7 +3,10 @@
 %:
 	dh $@ --with python-virtualenv
 
+REQUIREMENTS_FILE=requirements/build-requirements.txt
+
 override_dh_virtualenv:
+	test -e $(REQUIREMENTS_FILE)
 	dh_virtualenv \
 		--python /usr/bin/python3 \
 		--setuptools \
@@ -14,7 +17,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
 		--extra-pip-arg "--no-use-pep517" \
-		--requirements build-requirements.txt
+		--requirements $(REQUIREMENTS_FILE)
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/securedrop-log/debian/rules
+++ b/securedrop-log/debian/rules
@@ -3,7 +3,10 @@
 %:
 	dh $@ --with python-virtualenv
 
+REQUIREMENTS_FILE=requirements/build-requirements.txt
+
 override_dh_virtualenv:
+	test -e $(REQUIREMENTS_FILE)
 	dh_virtualenv \
 		--python /usr/bin/python3 \
 		--setuptools \
@@ -14,7 +17,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir" \
 		--extra-pip-arg "--no-use-pep517" \
-		--requirements build-requirements.txt
+		--requirements $(REQUIREMENTS_FILE)
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete


### PR DESCRIPTION
# Description

Just like we did here: https://github.com/freedomofpress/securedrop-debian-packaging/pull/266 use the latest path for the build requirements file