### PR TITLE
Bump securedrop-client to 0.5.1

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.5.1+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 02 Dec 2021 16:41:49 -0800
+
 securedrop-client (0.5.0+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
Hotfix release to resolve a broken build for 0.5.0.
Bumping version in order for clarity about communicating versions.