### PR TITLE
pause all nightlies for securedrop-client 0.6.0 QA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,28 +457,31 @@ workflows:
   # Nightly jobs for each package are run in series to ensure there are no
   # conflicts or race conditions when committing deb packages to git-lfs.
   # Each nightly job requires the completion of the previous task in the sequence.
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - build-nightly-buster-securedrop-client
-      - build-nightly-buster-securedrop-proxy:
-          requires:
-            - build-nightly-buster-securedrop-client
-      - build-nightly-buster-securedrop-export:
-          requires:
-            - build-nightly-buster-securedrop-proxy
-      - build-nightly-buster-securedrop-log:
-          requires:
-            - build-nightly-buster-securedrop-export
-      - build-nightly-buster-securedrop-workstation-svs-disp:
-          requires:
-            - build-nightly-buster-securedrop-log
-      - build-nightly-buster-securedrop-workstation-config:
-          requires:
-            - build-nightly-buster-securedrop-workstation-svs-disp
+  #
+  # PAUSE ALL WORKSTATION NIGHTLIES FOR QA
+  #
+  # nightly:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 6 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main
+  #   jobs:
+  #     - build-nightly-buster-securedrop-client
+  #     - build-nightly-buster-securedrop-proxy:
+  #         requires:
+  #           - build-nightly-buster-securedrop-client
+  #     - build-nightly-buster-securedrop-export:
+  #         requires:
+  #           - build-nightly-buster-securedrop-proxy
+  #     - build-nightly-buster-securedrop-log:
+  #         requires:
+  #           - build-nightly-buster-securedrop-export
+  #     - build-nightly-buster-securedrop-workstation-svs-disp:
+  #         requires:
+  #           - build-nightly-buster-securedrop-log
+  #     - build-nightly-buster-securedrop-workstation-config:
+  #         requires:
+  #           - build-nightly-buster-securedrop-workstation-svs-disp


### PR DESCRIPTION
# Description

Pause SDW nightlies so that we don't clobber environments during QA of `securedrop-client 0.6.0`. See release tracking issue: https://github.com/freedomofpress/securedrop-client/issues/1402 (there is a step to unpause nightlies so that we don't forget to undo this)