### PR TITLE
securedrop-client 0.6.0-rc3

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.6.0-rc3+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 09 Feb 2022 09:54:19 -0800
+
 securedrop-client (0.6.0-rc2+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
Bumping version, in line with https://github.com/freedomofpress/securedrop-client/pull/1421. Should be reviewed together. 