### PR TITLE
Bump changelog for securedrop-client 0.6.0

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,20 +1,8 @@
-securedrop-client (0.6.0-rc3+buster) unstable; urgency=medium
+securedrop-client (0.6.0+buster) unstable; urgency=medium
 
   * See changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Wed, 09 Feb 2022 09:54:19 -0800
-
-securedrop-client (0.6.0-rc2+buster) unstable; urgency=medium
-
-  * See changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Wed, 02 Feb 2022 10:17:09 -0800
-
-securedrop-client (0.6.0-rc1+buster) unstable; urgency=medium
-
-  * See changelog.md 
-
- -- SecureDrop Team <securedrop@freedom.press>  Wed, 26 Jan 2022 12:46:11 -0800
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 10 Feb 2022 12:50:55 -0800
 
 securedrop-client (0.5.1+buster) unstable; urgency=medium
 


### PR DESCRIPTION
Bump version of `securedrop-client` package to 0.6.0, preparing for final release. Refs https://github.com/freedomofpress/securedrop-client/issues/1402. Should be reviewed in tandem with https://github.com/freedomofpress/securedrop-client/pull/1425