### PR TITLE
securedrop-client 0.6.0-rc4

### DIFF
--- a/scripts/update-changelog
+++ b/scripts/update-changelog
@@ -42,4 +42,4 @@ if [[ ! -f "$changelog" ]]; then
     exit 4
 fi
 
-dch --newversion "${PKG_VERSION}+${PLATFORM}" --distribution unstable -c "$changelog"
+dch -b --newversion "${PKG_VERSION}+${PLATFORM}" --distribution unstable -c "$changelog"

--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,8 +1,8 @@
-securedrop-client (0.6.0+buster) unstable; urgency=medium
+securedrop-client (0.6.0-rc4+buster) unstable; urgency=medium
 
   * See changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Thu, 10 Feb 2022 12:50:55 -0800
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 14 Feb 2022 15:52:57 -0800
 
 securedrop-client (0.5.1+buster) unstable; urgency=medium
 


### PR DESCRIPTION
We're not final on 0.6.0 just yet. Create another rc.

Related to https://github.com/freedomofpress/securedrop-client/pull/1427