### PR TITLE
Revert "pause all nightlies for securedrop-client 0.6.0 QA"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,31 +457,28 @@ workflows:
   # Nightly jobs for each package are run in series to ensure there are no
   # conflicts or race conditions when committing deb packages to git-lfs.
   # Each nightly job requires the completion of the previous task in the sequence.
-  #
-  # PAUSE ALL WORKSTATION NIGHTLIES FOR QA
-  #
-  # nightly:
-  #   triggers:
-  #     - schedule:
-  #         cron: "0 6 * * *"
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
-  #   jobs:
-  #     - build-nightly-buster-securedrop-client
-  #     - build-nightly-buster-securedrop-proxy:
-  #         requires:
-  #           - build-nightly-buster-securedrop-client
-  #     - build-nightly-buster-securedrop-export:
-  #         requires:
-  #           - build-nightly-buster-securedrop-proxy
-  #     - build-nightly-buster-securedrop-log:
-  #         requires:
-  #           - build-nightly-buster-securedrop-export
-  #     - build-nightly-buster-securedrop-workstation-svs-disp:
-  #         requires:
-  #           - build-nightly-buster-securedrop-log
-  #     - build-nightly-buster-securedrop-workstation-config:
-  #         requires:
-  #           - build-nightly-buster-securedrop-workstation-svs-disp
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - build-nightly-buster-securedrop-client
+      - build-nightly-buster-securedrop-proxy:
+          requires:
+            - build-nightly-buster-securedrop-client
+      - build-nightly-buster-securedrop-export:
+          requires:
+            - build-nightly-buster-securedrop-proxy
+      - build-nightly-buster-securedrop-log:
+          requires:
+            - build-nightly-buster-securedrop-export
+      - build-nightly-buster-securedrop-workstation-svs-disp:
+          requires:
+            - build-nightly-buster-securedrop-log
+      - build-nightly-buster-securedrop-workstation-config:
+          requires:
+            - build-nightly-buster-securedrop-workstation-svs-disp


### PR DESCRIPTION
This reverts commit e4cbdbb16c226124af7f2b7221b25a90821994d9, to unpause SDW nightlies, see https://github.com/freedomofpress/securedrop-debian-packaging/pull/286 for more info.