### PR TITLE
Preload github.com SSH fingerprint in reprepro-update-tor CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,7 @@ jobs:
             apt-get install -y reprepro ca-certificates dctrl-tools git git-lfs openssh-client
 
             # Clone the dev repo and configure it
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
             git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
             cd securedrop-dev-packages-lfs
             git lfs install


### PR DESCRIPTION
The job is currently failing with:
> Cloning into 'securedrop-dev-packages-lfs'...
> The authenticity of host 'github.com (140.82.114.3)' can't be established.
> ECDSA key fingerprint is SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM.
> Are you sure you want to continue connecting (yes/no/[fingerprint])?

It's unclear to me how the other nightly jobs are getting the correct
fingerprint but this should do it for this job.