### PR TITLE
[SPIKE] Update workstation-grsec for Bullseye

### DIFF
--- a/scripts/update-changelog
+++ b/scripts/update-changelog
@@ -33,7 +33,8 @@ if [[ -z "${PKG_VERSION:-}" ]]; then
     exit 3
 fi
 
-PLATFORM="$(lsb_release -sc)"
+_PKG_PLATFORM="$(lsb_release -sc)"
+PLATFORM="${PKG_PLATFORM:-$_PKG_PLATFORM}"
 
 # Update the changelog.
 changelog="${TOPLEVEL}/${PKG_NAME}/debian/changelog-${PLATFORM}"

--- a/securedrop-workstation-grsec/debian/changelog-bullseye
+++ b/securedrop-workstation-grsec/debian/changelog-bullseye
@@ -1,6 +1,6 @@
-securedrop-workstation-grsec (5.15.33+bullseye) unstable; urgency=medium
+securedrop-workstation-grsec (5.15.38+bullseye) unstable; urgency=medium
 
-  * Bump kernel version to 5.15.33
+  * Bump kernel version to 5.15.38
   * Add support for Debian 11 Bullseye
   * Removes u2mfn references from postinst
 

--- a/securedrop-workstation-grsec/debian/changelog-bullseye
+++ b/securedrop-workstation-grsec/debian/changelog-bullseye
@@ -1,0 +1,7 @@
+securedrop-workstation-grsec (5.15.33+bullseye) unstable; urgency=medium
+
+  * Bump kernel version to 5.15.33
+  * Add support for Debian 11 Bullseye
+  * Removes u2mfn references from postinst
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 05 Apr 2022 13:35:48 -0700

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,12 +8,12 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 5.15.33
+upstream_version: 5.15.38
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
 Pre-Depends: qubes-kernel-vm-support (>=4.0.31)
-Depends: linux-image-5.15.33-grsec-workstation,linux-headers-5.15.33-grsec-workstation,libelf-dev,paxctld
+Depends: linux-image-5.15.38-grsec-workstation,linux-headers-5.15.38-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -8,12 +8,12 @@ Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git
 
 Package: securedrop-workstation-grsec
-upstream_version: 4.14.241
+upstream_version: 5.15.33
 debian_revision: 1
 Architecture: amd64
 Provides: securedrop-workstation-grsec-latest
 Pre-Depends: qubes-kernel-vm-support (>=4.0.31)
-Depends: linux-image-4.14.241-grsec-workstation,linux-headers-4.14.241-grsec-workstation,libelf-dev,paxctld
+Depends: linux-image-5.15.33-grsec-workstation,linux-headers-5.15.33-grsec-workstation,libelf-dev,paxctld
 Description: Linux for SecureDrop Workstation template (meta-package)
  Metapackage providing a grsecurity-patched Linux kernel for use in SecureDrop
  Workstation Qubes templates. Depends on the most recently built patched kernel

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -18,14 +18,12 @@ set -e
 # the debian-policy package
 
 
-# When updating the kernel version, also check that the u2mfn version matches:
-# https://github.com/QubesOS/qubes-linux-utils/blob/release4.0/version
-GRSEC_VERSION='4.14.241-grsec-workstation'
-U2MFN_VERSION="4.0.34"
+GRSEC_VERSION='5.15.33-grsec-workstation'
 
 # Sets default grub boot parameter to the kernel version specified
-# by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus
-# supersedes this 4.14.x series grsecurity kernel at boot-time
+# by $GRSEC_VERSION. Given that Debian Bullseye defaults to 5.10,
+# any 5.15.x kernel will automatically supersede the default.
+# We still set the expected kernel version explicitly.
 set_grub_default() {
     GRUB_OPT="'Advanced options for Debian GNU/Linux>Debian GNU/Linux, with Linux $GRSEC_VERSION'"
     perl -pi -e "s|^GRUB_DEFAULT=.*|GRUB_DEFAULT=$GRUB_OPT|" /etc/default/grub
@@ -42,34 +40,10 @@ start_paxctld() {
     fi
 }
 
-# Checks that the u2mfn kernel module was successfully built via dkms.
-verify_u2mfn_exists() {
-    ko_filepath="/usr/lib/modules/${GRSEC_VERSION}/updates/dkms/u2mfn.ko"
-    if ! test -f "$ko_filepath"; then
-        return 1
-    fi
-}
-
-# For reasons unknown, u2mfn may be missing. If not found, try to rebuild it,
-# otherwise we'll fail and require admin intervention.
-ensure_u2mfn_exists() {
-    if ! verify_u2mfn_exists ; then
-        dkms remove u2mfn -v "$U2MFN_VERSION" -k "$GRSEC_VERSION" || true
-        dkms autoinstall -k "$GRSEC_VERSION"
-        if ! verify_u2mfn_exists ; then
-            echo "ERROR: u2mfn kernel object is missing: $ko_filepath"
-            exit 1
-        fi
-    fi
-}
-
 case "$1" in
     configure)
     # Ensure pax flags are set prior to running grub
     start_paxctld
-    # Rebuild u2mfn kernel module if missing
-    ensure_u2mfn_exists
-    # Force latest hardened kernel for next boot
     set_grub_default
     update-grub
     ;;

--- a/securedrop-workstation-grsec/debian/postinst
+++ b/securedrop-workstation-grsec/debian/postinst
@@ -18,7 +18,7 @@ set -e
 # the debian-policy package
 
 
-GRSEC_VERSION='5.15.33-grsec-workstation'
+GRSEC_VERSION='5.15.38-grsec-workstation'
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION. Given that Debian Bullseye defaults to 5.10,


### PR DESCRIPTION
Builds a new `securedrop-workstation-grsec` metapackage for
Debian 11 Bullseye, intended for use with Qubes 4.1. Major changes:

  * upgrades kernel series 4.14.x -> 5.15.x
  * removes u2mfn references (not necessary under Qubes 4.1)

This change was made indelicately to the build logic: no care was taken
to preserve functionality for the oldstable Buster grsec logic. As such, we should not merge as-is. The work is presented in draft form related to spike in https://github.com/freedomofpress/qubes-template-securedrop-workstation/pull/24