### PR TITLE
Publish workstation nightlies in a separate nighly component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,8 +209,8 @@ common-steps:
         git config user.name "sdcibot"
 
         # Copy built debian packages to the relevant workstation repo and git push.
-        cp ~/project/build/debbuild/packaging/*.deb ./workstation/${PLATFORM}/
-        git add workstation/${PLATFORM}/*.deb
+        cp ~/project/build/debbuild/packaging/*.deb ./workstation/${PLATFORM}-nightlies/
+        git add workstation/${PLATFORM}-nightlies/*.deb
         git commit -m "Automated SecureDrop workstation build"
         git push origin main
 


### PR DESCRIPTION
Once <https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/145>
lands, our reprepro script will treat the new `workstation/buster-nightlies`
directory as going to a separate nightlies component, which keeps main
clear for manually uploaded release candidates.

Fixes #289.