### PR TITLE
Update changelog for securedrop-client0 0.7.0-rc2

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.7.0-rc2+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 18 Apr 2022 15:35:08 -0700
+
 securedrop-client (0.7.0-rc1+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
# Description

Update changelog for securedrop-client 0.7.0-rc2.

Towards https://github.com/freedomofpress/securedrop-client/issues/1465

# Test Plan

- [ ] Passes visual inspection