### PR TITLE
update changelog for securedrop-client 0.7.0-rc3

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.7.0-rc3+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 19 Apr 2022 15:14:08 -0700
+
 securedrop-client (0.7.0-rc2+buster) unstable; urgency=medium
 
   * See changelog.md 


### PR DESCRIPTION
# Description

Update changelog for securedrop-client 0.7.0-rc3

Towards https://github.com/freedomofpress/securedrop-client/issues/1465

# Test Plan

- [ ] CI passes except for known issue: https://github.com/freedomofpress/securedrop-debian-packaging/issues/298
- [ ] Passes visual inspection