### PR TITLE
Update changelog for securedrop-client 0.7.0

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,20 +1,8 @@
-securedrop-client (0.7.0-rc3+buster) unstable; urgency=medium
-
-  * See changelog.md 
-
- -- SecureDrop Team <securedrop@freedom.press>  Tue, 19 Apr 2022 15:14:08 -0700
-
-securedrop-client (0.7.0-rc2+buster) unstable; urgency=medium
-
-  * See changelog.md 
-
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 18 Apr 2022 15:35:08 -0700
-
-securedrop-client (0.7.0-rc1+buster) unstable; urgency=medium
+securedrop-client (0.7.0+buster) unstable; urgency=medium
 
   * See changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 11 Apr 2022 18:17:56 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 20 Apr 2022 10:41:31 -0400
 
 securedrop-client (0.6.0+buster) unstable; urgency=medium
 


### PR DESCRIPTION
Update changelog for securedrop-client 0.7.0

Towards https://github.com/freedomofpress/securedrop-client/issues/1465