### PR TITLE
Pass --no-clean-on-error to reprotest for easier debugging

### DIFF
--- a/tests/test_reproducible_debian_packages.py
+++ b/tests/test_reproducible_debian_packages.py
@@ -42,6 +42,7 @@ def test_deb_builds_are_reproducible(pkg_name):
         f"make {pkg_name}",
         "--variations",
         "-all, -kernel, +exec_path, +build_path",
+        "--no-clean-on-error",
         ".",
         f"build/debbuild/packaging/{pkg_name}*.deb",
     ]


### PR DESCRIPTION
When reprotest fails, leave the environment behind for easier
interactive debugging of specific commands that failed. In CI everything
is thrown away anyways, so this should only affect people locally
running reprotest.

Refs #298.