### PR TITLE
Have CI delete nightlies older than 2 weeks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,35 @@ jobs:
             # If there are changes, diff-index will fail, so we commit and push
             git diff-index --quiet HEAD || git commit -m "Automatically updating Tor packages" && git push origin main
 
+  clean-old-nightlies:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *addsshkeys
+      - run:
+          name: clone and delete old nightlies
+          command: |
+            apt-get update
+            apt-get install -y python3 ca-certificates git git-lfs openssh-client
+
+            # Clone the dev repo and configure it
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
+            cd securedrop-dev-packages-lfs
+            git lfs install
+            git config user.email "securedrop@freedom.press"
+            git config user.name "sdcibot"
+
+            # Run the clean script and `git add` any deletions
+            cd ..
+            ./scripts/clean-old-nightlies.py securedrop-dev-packages-lfs/workstation/buster-nightlies
+            cd securedrop-dev-packages-lfs
+            git add .
+
+            # If there are changes, diff-index will fail, so we commit and push
+            git diff-index --quiet HEAD || git commit -m "Deleting old nightlies" && git push origin main
+
+
   build-buster-securedrop-log:
     docker:
       - image: circleci/python:3.7-buster
@@ -516,4 +545,6 @@ workflows:
       - build-nightly-buster-securedrop-workstation-config:
           requires:
             - build-nightly-buster-securedrop-workstation-svs-disp
-
+      - clean-old-nightlies:
+          requires:
+            - build-nightly-buster-securedrop-workstation-config

--- a/scripts/clean-old-nightlies.py
+++ b/scripts/clean-old-nightlies.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Clean up nightly packages that are older than 14 days
+
+Example:
+    ./clean-old-nightlies.py securedrop-dev-packages-lfs/workstation/buster-nightlies
+
+"""
+import argparse
+import datetime
+import pathlib
+import re
+
+
+DELETE_OLDER_THAN = 14
+PATTERN = re.compile(r'-dev-(\d{8})-')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Cleans up old nighly packages"
+    )
+    parser.add_argument(
+        "directory",
+        type=pathlib.Path,
+        help="Directory to clean up",
+    )
+    args = parser.parse_args()
+    if not args.directory.is_dir():
+        raise RuntimeError(f"Directory, {args.directory}, doesn't exist")
+    cutoff = str(datetime.date.today() - datetime.timedelta(days=DELETE_OLDER_THAN)).replace('-', '')
+    print(f'Deleting files older than {cutoff}')
+    for deb in args.directory.glob('*.deb'):
+        search = PATTERN.search(deb.name)
+        if search:
+            age = search.group(1)
+            if age < cutoff:
+                print(f'Deleting {deb.name}...')
+                deb.unlink()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Have CI run a quick Python script that will delete workstation nightlies
after 2 weeks to keep the repository size down.

This job requires the previous nightly builds to succeed, so if the
nightlies break for whatever reason, deletion will also be paused.

## Test plan
* [ ] Check out this repo and securedrop-dev-packages-lfs side by side
* [ ] Manually run the commands CI would, up till the point where the commit is created (but don't push)