### PR TITLE
Add missing "checkout" step for clean-old-nightlies job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,7 @@ jobs:
     docker:
       - image: debian:bullseye
     steps:
+      - checkout
       - *addsshkeys
       - run:
           name: clone and delete old nightlies


### PR DESCRIPTION
The job was failing with:
> /bin/bash: line 14: ./scripts/clean-old-nightlies.py: No such file or directory

I was missing the special "checkout" job that clones the current git
repo and puts it in the working directory, see
<https://circleci.com/docs/2.0/configuration-reference/#checkout>.