### PR TITLE
update changelog for securedrop-workstation-config 0.1.7

### DIFF
--- a/securedrop-workstation-config/debian/changelog-buster
+++ b/securedrop-workstation-config/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-config (0.1.7+buster) unstable; urgency=medium
+
+  * Add mp4 to allow-list for sd-viewer
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 02 May 2022 16:05:46 -0700
+
 securedrop-workstation-config (0.1.6+buster) unstable; urgency=medium
 
   * Bugfix in .desktop file syntax; improved Fail Closed behavior


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-debian-packaging/issues/312

Once this is merged, we can tag `securedrop-debian-packaging` and build a new `securedrop-workstation-config` debian package an push to `securedrop-dev-pacakges-lfs`.