### PR TITLE
Only install reprotest when needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,7 @@ jobs:
           name: install test requirements, run linters, and run tests
           command: |
             make install-deps
+            sudo apt-get install reprotest -y
             make lint-desktop-files
             virtualenv -p /usr/bin/python3 .venv
             source .venv/bin/activate
@@ -233,6 +234,7 @@ jobs:
           name: install test requirements and run tests
           command: |
             make install-deps
+            sudo apt-get install reprotest -y
             source .venv/bin/activate
             pip install -r test-requirements.txt
             sudo sed -i -re "292s/^(\s+).*\$/\1return _.prepend_to_build_command_raw('')/" /usr/lib/python3/dist-packages/reprotest/build.py
@@ -247,6 +249,7 @@ jobs:
           name: install test requirements and run tests
           command: |
             make install-deps
+            sudo apt-get install reprotest -y
             source .venv/bin/activate
             pip install -r test-requirements.txt
             # Patch reprotest in-place to skip 'setarch' prefix, which fails under containers.

--- a/scripts/install-deps
+++ b/scripts/install-deps
@@ -18,7 +18,6 @@ sudo apt-get install  \
     python3-pip \
     python3-venv \
     python3-setuptools \
-    reprotest \
     desktop-file-utils -y
 
 # Inspect the wheel files present locally. If repo was cloned


### PR DESCRIPTION
This will dramatically shrink the number of dependencies needed when
running `install-deps` from 4GB to 200MB because all of the diffoscope
dependencies aren't needed.

We only need reprotest for three different CI pipelines, so manually install
it there instead of everywhere.

Fixes #318.

----
Without this change:
![Screenshot 2022-05-16 at 15-42-57 Pipelines - freedomofpress_securedrop-debian-packaging](https://user-images.githubusercontent.com/81392/168670913-a8cda405-39c4-444c-9f41-704127b22a90.png)

With this change:
![Screenshot 2022-05-16 at 15-48-49 Pipelines - freedomofpress_securedrop-debian-packaging](https://user-images.githubusercontent.com/81392/168670923-a6dcb999-4987-4aad-82c8-83a0de857ab8.png)

So we're looking at a ~2min speed up for the main build jobs, which should be a noticable speedup on the various component repositories. And spinning up a new container locally will no longer have to download 4G worth of packages...