### PR TITLE
More bullseye fixes

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -27,8 +27,8 @@ TOP_BUILDDIR="$PWD/build/debbuild/packaging"
 mkdir -p "$TOP_BUILDDIR"
 rm -rf "${TOP_BUILDDIR:?}/${PKG_NAME}"
 mkdir -p "${TOP_BUILDDIR}/${PKG_NAME}"
-# Move changelog into place (we have separate changelogs for each platform)
-PLATFORM="${PKG_PLATFORM:-buster}"
+# Platform metadata
+source /etc/os-release
 
 # Validate required args.
 if [[ -z "${PKG_NAME:-}" ]]; then
@@ -140,10 +140,13 @@ printf "Building package '%s' from version '%s'...\\n" "$PKG_NAME" "$PKG_VERSION
 echo "$TOP_BUILDDIR/$PKG_NAME/"
 
 # Legacy: Move platform-specific changelog into place
-if [[ -f "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-$PLATFORM" ]]; then
-    echo "Moving legacy $PLATFORM changelog into place"
-    mv "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-$PLATFORM" "$TOP_BUILDDIR/$PKG_NAME/debian/changelog"
+if [[ -f "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-buster" ]]; then
+    echo "Moving legacy buster changelog into place"
+    mv "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-buster" "$TOP_BUILDDIR/$PKG_NAME/debian/changelog"
 fi
+
+# Adjust platform in version number with sed magic to only replace the first instance
+sed -i "0,/buster/s//${VERSION_CODENAME}/" debian/changelog
 
 # Adds reproducibility step
 SOURCE_DATE_EPOCH="$(dpkg-parsechangelog -STimestamp)"

--- a/scripts/install-deps
+++ b/scripts/install-deps
@@ -16,6 +16,7 @@ sudo apt-get install  \
     libyaml-dev \
     python3-all \
     python3-pip \
+    python3-virtualenv \
     python3-venv \
     python3-setuptools \
     desktop-file-utils -y


### PR DESCRIPTION
First, explicitly install python3-virtualenv
    
The version of dh_virtualenv on bullseye allows using `python3-venv` and
if present, won't install `python3-virtualenv`. Since we still need
virtualenv, install it explicitly for now until we can transition to
using venv.

Second, automatically determine platform being built for
    
Instead of requiring `PKG_PLATFORM` to manually be set, we can get the
current platform from `/etc/os-release`.

The build script will also now adjust the platform in the version
number, so we don't need to maintain separate changelogs that are
identical except for version.

Refs #321.

## Test plan
* [ ] Spin up a bullseye container/VM, run `make install-deps`
* [ ] Edit securedrop-log/debian/rules to remove the `--setuptools` flag to dh_virtualenv
* [ ] run `PKG_GITREF=main make securedrop-log` and watch as you get a bullseye deb!
* [ ] Now switch back to a buster container/VM, run `make install-deps`
* [ ] Run `PKG_GITREF=main make securedrop-log` and you still get a buster deb!