### PR TITLE
Test securedrop-keyring on bullseye and add nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ common-steps:
 
   - &commitworkstationdebs
     run:
-      name: Commit workstation debs for deployment to apt-test-qubes.freedom.press
+      name: Commit workstation debs for deployment to apt-test.freedom.press
       command: |
         PLATFORM="$(lsb_release -sc)"
         git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
@@ -198,6 +198,7 @@ common-steps:
         git config user.name "sdcibot"
 
         # Copy built debian packages to the relevant workstation repo and git push.
+        mkdir -p ./workstation/${PLATFORM}-nightlies/
         cp ~/project/build/debbuild/packaging/*.deb ./workstation/${PLATFORM}-nightlies/
         git add workstation/${PLATFORM}-nightlies/*.deb
         git commit -m "Automated SecureDrop workstation build"
@@ -484,6 +485,42 @@ jobs:
       - *setmetapackageversion
       - *builddebianpackage
 
+  build-bullseye-securedrop-keyring:
+    docker:
+      - image: circleci/python:3.9-bullseye
+    steps:
+      - checkout
+      - *installdeps
+      - *setsdkeyringname
+      - *setmetapackageversion
+      - *builddebianpackage
+
+  build-nightly-buster-securedrop-keyring:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *installdeps
+      - *setsdkeyringname
+      - *getnightlymetapackageversion
+      - *updatedebianchangelog
+      - *builddebianpackage
+      - *addsshkeys
+      - *commitworkstationdebs
+
+  build-nightly-bullseye-securedrop-keyring:
+    docker:
+      - image: circleci/python:3.9-bullseye
+    steps:
+      - checkout
+      - *installdeps
+      - *setsdkeyringname
+      - *getnightlymetapackageversion
+      - *updatedebianchangelog
+      - *builddebianpackage
+      - *addsshkeys
+      - *commitworkstationdebs
+
 workflows:
   build-packages:
     jobs:
@@ -498,6 +535,7 @@ workflows:
       - build-buster-securedrop-workstation-grsec
       - build-buster-securedrop-workstation-config
       - build-buster-securedrop-keyring
+      - build-bullseye-securedrop-keyring
 
   # Nightly jobs for each package are run in series to ensure there are no
   # conflicts or race conditions when committing deb packages to git-lfs.
@@ -530,6 +568,13 @@ workflows:
       - build-nightly-buster-securedrop-workstation-config:
           requires:
             - build-nightly-buster-securedrop-workstation-svs-disp
-      - clean-old-nightlies:
+      - build-nightly-buster-securedrop-keyring:
           requires:
             - build-nightly-buster-securedrop-workstation-config
+      - build-nightly-bullseye-securedrop-keyring:
+          requires:
+            - build-nightly-buster-securedrop-keyring
+      # Cleaning old nightlies should always be the last step
+      - clean-old-nightlies:
+          requires:
+            - build-nightly-bullseye-securedrop-keyring

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,7 @@ common-steps:
     run:
       name: Create nightly version for metapackages
       command: |
-        PLATFORM="$(lsb_release -sc)"
-        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ~/project/${PKG_NAME}/debian/changelog-${PLATFORM} | head -n1)
+        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ~/project/${PKG_NAME}/debian/changelog-buster | head -n1)
         # Nightly versioning format is: LATEST_TAG-dev-YYMMDD-HHMMSS
         export VERSION_TO_BUILD="$CURRENT_VERSION-dev-$(date +%Y%m%d)-$(date +%H%M%S)"
         # Enable access to this env var in subsequent run steps
@@ -120,8 +119,7 @@ common-steps:
         cd ~/project/$PKG_NAME/debian
         export DEBFULLNAME='Automated builds'
         export DEBEMAIL=securedrop@freedom.press
-        export PLATFORM="$(lsb_release -sc)"
-        dch --changelog changelog-${PLATFORM} --distribution unstable --package "$PKG_NAME" --newversion $VERSION_TO_BUILD+${PLATFORM} "This is an automated build."
+        dch --changelog changelog-buster --distribution unstable --package "$PKG_NAME" --newversion $VERSION_TO_BUILD+buster "This is an automated build."
 
   - &builddebianpackage
     run:
@@ -182,8 +180,7 @@ common-steps:
     run:
       name: Get metapackage version via distribution changelog
       command: |
-        PLATFORM="$(lsb_release -sc)"
-        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ${PKG_NAME}/debian/changelog-${PLATFORM} | head -n1)
+        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ${PKG_NAME}/debian/changelog-buster | head -n1)
         export VERSION_TO_BUILD="$CURRENT_VERSION"
         # Enable access to this env var in subsequent run steps
         echo $VERSION_TO_BUILD > ~/packaging/sd_version


### PR DESCRIPTION
* Hardcode `changelog-buster` since we're not ready to rename it to
  a generic `changelog` yet, but we want to enable bullseye builds.
* Add job for building securedrop-keyring on bullseye
* Add buster+bullseye nightlies for the keyring to continually ensure
  the package is buildable even though it rarely changes.
* Ensure the nightly directory exists with `mkdir -p` since the bullseye
  one doesn't exist yet.
