### PR TITLE
update changelog for securedrop-workstation-config bullseye 0.1.7

### DIFF
--- a/securedrop-workstation-config/debian/changelog-bullseye
+++ b/securedrop-workstation-config/debian/changelog-bullseye
@@ -1,0 +1,5 @@
+securedrop-workstation-config (0.1.7+buster) unstable; urgency=medium
+
+  * Add securedrop-workstation-config 0.1.7 for bullseye
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 23 May 2022 21:06:58 -0700


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-debian-packaging/issues/321

* Add bullseye changelog for securedrop-workstation-grsec
* Add job for building securedrop-workstation-grsec in CI

Cross link to https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/159

Once merged, you can push to `pleasebuildnightlies` to test if CI properly builds the package. 