### PR TITLE
Fix template for `securedrop-log` nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ jobs:
 
   build-nightly-bullseye-securedrop-log:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: circleci/python:3.9-bullseye
     steps:
       - checkout
       - *removevirtualenv


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-debian-packaging/issues/321

As it says on the tin (thanks to @creviera [for flagging](https://github.com/freedomofpress/securedrop-debian-packaging/pull/325/files#r881086513))