### PR TITLE
Fix building packages when PKG_PATH doesn't end in PKG_NAME

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -98,7 +98,7 @@ if [[ "${PKG_NAME}" =~ ^(securedrop-client|securedrop-proxy|securedrop-export|se
         # Build from source
         echo "PKG_PATH not set, building from source (version $PKG_VERSION)..."
         setup_source_tree
-        PKG_PATH="/tmp/${PKG_NAME}"
+        PKG_PATH="/tmp/${PKG_NAME}/"
     else
         if [[ -f "${PKG_PATH}" ]]; then
             # It's a file and not a directory, must be a legacy tarball
@@ -106,13 +106,13 @@ if [[ "${PKG_NAME}" =~ ^(securedrop-client|securedrop-proxy|securedrop-export|se
             rm -rf "/tmp/${PKG_NAME}"
             mkdir -p "/tmp/${PKG_NAME}"
             tar --strip-components=1 -C "/tmp/$PKG_NAME" -xvf "$PKG_PATH"
-            PKG_PATH="/tmp/${PKG_NAME}"
+            PKG_PATH="/tmp/${PKG_NAME}/"
         fi
     fi
 
 
     # Copy the source tree to the packaging workspace
-    cp -r "$PKG_PATH" "$TOP_BUILDDIR/"
+    cp -rT "$PKG_PATH" "$TOP_BUILDDIR/$PKG_NAME/"
 
     # Hop into the package build dir, to run dpkg-buildpackage
     cd "$TOP_BUILDDIR/$PKG_NAME/"


### PR DESCRIPTION
There's a subtle bug in which we (read: I) incorrectly assumed that
PKG_PATH will always end in PKG_NAME, so copying it over into
$TOP_BUILDDIR will create the appropriately named subdirectory and
everything is happy.

This assumption is wrong in all the component repository CI pipelines,
where the path points to a directory named "project". Adjust the `cp`
command with the magic `-T` flag to stick the files in the correctly
named directory that we expect later on.

Thanks to Gonzalo for helping with debugging.