### PR TITLE
set debhelper compat to 11 for all projects

### DIFF
--- a/securedrop-client/debian/control
+++ b/securedrop-client/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-client
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 12), dh-python, python3-all, python3-setuptools, dh-virtualenv
+Build-Depends: debhelper-compat (= 11), dh-python, python3-all, python3-setuptools, dh-virtualenv
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-client
 X-Python3-Version: >= 3.5

--- a/securedrop-export/debian/control
+++ b/securedrop-export/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-export
 Section: utils
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 12), dh-python, python3-all, python3-setuptools, dh-virtualenv
+Build-Depends: debhelper-compat (= 11), dh-python, python3-all, python3-setuptools, dh-virtualenv
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-export
 Vcs-Git: https://github.com/freedomofpress/securedrop-export.git

--- a/securedrop-keyring/debian/control
+++ b/securedrop-keyring/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-keyring
 Section: web
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9),
+Build-Depends: debhelper (>= 11),
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
 

--- a/securedrop-log/debian/control
+++ b/securedrop-log/debian/control
@@ -3,10 +3,9 @@ Section: utils
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Build-Depends:
- debhelper-compat (= 12),
+ debhelper-compat (= 11),
  dh-python,
  python3-all,
- python3-setuptools,
  dh-virtualenv,
  python3-distutils
 Standards-Version: 3.9.8

--- a/securedrop-proxy/debian/control
+++ b/securedrop-proxy/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-proxy
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools, dh-virtualenv
+Build-Depends: debhelper (>= 11), dh-python, python3-all, python3-setuptools, dh-virtualenv
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-proxy
 X-Python3-Version: >= 3.5

--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -9,7 +9,6 @@ override_dh_virtualenv:
 	test -e $(REQUIREMENTS_FILE)
 	dh_virtualenv \
 		--python /usr/bin/python3 \
-		--setuptools \
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-index" \
 		--extra-pip-arg "--find-links" \

--- a/securedrop-workstation-config/debian/control
+++ b/securedrop-workstation-config/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-workstation-config
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9),
+Build-Depends: debhelper (>= 11),
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-workstation-config
 

--- a/securedrop-workstation-grsec/debian/control
+++ b/securedrop-workstation-grsec/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-workstation-grsec
 Section: kernel
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 11)
 Standards-Version: 3.9.8
 Homepage: https://securedrop.org
 Vcs-Git: https://github.com/freedomofpress/securedrop-workstation.git

--- a/securedrop-workstation-svs-disp/debian/control
+++ b/securedrop-workstation-svs-disp/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-workstation-svs-disp
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9),
+Build-Depends: debhelper (>= 11),
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
 

--- a/securedrop-workstation-viewer/debian/control
+++ b/securedrop-workstation-viewer/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-workstation-viewer
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9),
+Build-Depends: debhelper (>= 11),
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-debian-packaging/issues/333

When we bumped the debhelper compat level from 9 to 12, buster and bullseye packages could no longer be built in CI by pointing the builder at a source tarball that was generated by running: `python3 setup.py sdist`. 

We still want to bump the compat version up from 9 to 11 (we only remove `setuptools` in the rules file with this version bump because it's no longer needed). But too much is broken when we bump to 12, so I created an issue to capture the work involved in order to do that bump (https://github.com/freedomofpress/securedrop-debian-packaging/issues/335).

# Test plan

- [x] First confirm that you see the error in both your buster and bullseye build VMs without the fix
- [x] In a bullseye build environment, build a package using `PKG_PATH` but point it to a tarball you created in the project directory using `python3 setup.py sdist` and confirm you can build the package
- [x] In a buster build environment, build a package using `PKG_PATH` but point it to a tarball you created in the project directory using `python3 setup.py sdist` and confirm you can build the package