### PR TITLE
build(securedrop-export): reconcile dependencies uninstallable in bullseye

### DIFF
--- a/securedrop-export/debian/control
+++ b/securedrop-export/debian/control
@@ -10,7 +10,7 @@ X-Python-3-Version: >= 3.5
 
 Package: securedrop-export
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, task-print-server, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
+Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to 
  export submissions from the client to external storage, via the sd-export 


### PR DESCRIPTION
* Depends on freedomofpress/securedrop-dev-packages-lfs#161

Closes #343 by:

1. removing the `Depends` specification for `task-print-server`, which is no longer available in bullseye;
2. retaining the `Depends` specifications for `cups` and `system-config-printer`; and
3. retaining the `Depends` specification for `xpp`, which we host for bullseye after freedomofpress/securedrop-dev-packages-lfs#161.

## Test plan

* [ ] Review and merge freedomofpress/securedrop-dev-packages-lfs#161, so that `xpp` is available on `apt-test.freedom.press` in `bullseye main`.
* [ ] Push this branch to `please-build-nightlies`, so that a `securedrop-export` package with these changes is available on `apt-test.freedom.press` in `bullseye nightlies`.
* [ ] From `bullseye nightlies`, confirm that `sudo apt install securedrop-export` succeeds including the following dependencies:
    * [ ] `xpp` (from `bullseye nightlies`)
        * [ ] `libfltk1.1` (from upstream)