### PR TITLE
`securedrop-export`: Add printer driver dependencies

### DIFF
--- a/securedrop-export/debian/control
+++ b/securedrop-export/debian/control
@@ -10,7 +10,7 @@ X-Python-3-Version: >= 3.5
 
 Package: securedrop-export
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
+Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to 
  export submissions from the client to external storage, via the sd-export 


### PR DESCRIPTION
Previously (on buster) `task-print-server` would automatically install all printer drivers as it listed `printer-driver-all` as a recommended package. But it was removed as a dependency because it doesn't exist in bullseye anymore, so we want to explicitly depend on the printer drivers we need for this package.

Fixes #346