### PR TITLE
Remove `securedrop-export` printer driver dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,20 +517,6 @@ jobs:
       - *getnightlyversion
       - *builddebianpackage
 
-  build-nightly-buster-securedrop-export:
-    docker:
-      - image: circleci/python:3.7-buster
-    steps:
-      - checkout
-      - *removevirtualenv
-      - *installdeps
-      - *clonesecuredropexport
-      - *getnightlyversion
-      - *updatedebianchangelog
-      - *builddebianpackage
-      - *addsshkeys
-      - *commitworkstationdebs
-
   build-bullseye-securedrop-export:
     docker:
       - image: circleci/python:3.9-bullseye
@@ -773,12 +759,9 @@ workflows:
       - build-nightly-buster-securedrop-proxy:
           requires:
             - build-nightly-buster-securedrop-client
-      - build-nightly-buster-securedrop-export:
-          requires:
-            - build-nightly-buster-securedrop-proxy
       - build-nightly-buster-securedrop-log:
           requires:
-            - build-nightly-buster-securedrop-export
+            - build-nightly-buster-securedrop-proxy
       - build-nightly-buster-securedrop-workstation-viewer:
           requires:
             - build-nightly-buster-securedrop-log

--- a/securedrop-export/debian/control
+++ b/securedrop-export/debian/control
@@ -10,7 +10,7 @@ X-Python-3-Version: >= 3.5
 
 Package: securedrop-export
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
+Depends: ${python3:Depends}, ${misc:Depends}, cryptsetup, cups, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to 
  export submissions from the client to external storage, via the sd-export 


### PR DESCRIPTION
We do not depend on files provided by printer-driver packages
anymore!

This is a breaking change for buster, so it's also the end for buster
nightly packages.

Fixes #351

## Testing

- [ ] Build package for `securedrop-export` using the code from the [securedrop-export#94](https://github.com/freedomofpress/securedrop-export/pull/94) branch
- Transfer resulting `.deb` to `sd-large-bullseye-template` and install it with `dpkg -i`
- [ ] Run `apt autoremove`, verify that `printer-driver-brlaser` and `printer-driver-hpcups` were removed
- Shut down sd-large-bullseye-template
- [ ] (Cross reference) [securedrop-export#94 Part 2](https://github.com/freedomofpress/securedrop-export/pull/94) tests are successful