### PR TITLE
add changelog entry for securedrop-workstation-config 0.2.0

### DIFF
--- a/securedrop-workstation-config/debian/changelog-buster
+++ b/securedrop-workstation-config/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-config (0.2.0+buster) unstable; urgency=medium
+
+  * Update mimeapps.list.sd-viewer to work on Bullseye (Qubes 4.1) 
+ 
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 29 Jun 2022 15:25:05 -0700
+
 securedrop-workstation-config (0.1.7+buster) unstable; urgency=medium
 
   * Add mp4 to allow-list for sd-viewer


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-debian-packages-lfs/issues/84

* Add bullseye changelog for securedrop-workstation-config 0.2.0

Cross link to https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/163