### PR TITLE
Add securedrop-workstation-viewer-0.2.0 (bullseye) changelog entry

### DIFF
--- a/securedrop-workstation-viewer/debian/changelog-bullseye
+++ b/securedrop-workstation-viewer/debian/changelog-bullseye
@@ -1,0 +1,5 @@
+securedrop-workstation-viewer (0.2.0+bullseye) unstable; urgency=medium
+
+  * Move packages to debhelper-compat 11
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 22:03:18 -0400


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-debian-packages-lfs/issues/84