### PR TITLE
ci(reprotest-wheels): switch to Debian bullseye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
 
   reprotest-wheels:
     docker:
-      - image: quay.io/freedomofpress/packaging-debian-buster@sha256:16d2df1935807c6a751d0536e3cb36970c4c22d7324915d25ee84c90b032c307
+      - image: quay.io/freedomofpress/packaging-debian-bullseye@sha256:b23206cff095aa5f0764d03c18ff1212a386386b9026441cc36ea836b19b0919
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Now that we're assuming Python 3.9 under Debian bullseye, that's the
environment we should use for testing wheel-level reproducibility.

Closes #350.

## Test plan

- [x] `reprotest-wheels` passes (along with the rest of CI).
- [ ] Someone other than me, ideally @creviera, attests that this investigation constitutes adequate further testing of the `packaging-debian-bullseye` image per <https://github.com/freedomofpress/securedrop-debian-packaging/pull/317#pullrequestreview-969864489>.