### PR TITLE
Add (bullseye) changelog for securedrop-export-0.3.0

### DIFF
--- a/securedrop-export/debian/changelog-bullseye
+++ b/securedrop-export/debian/changelog-bullseye
@@ -1,0 +1,5 @@
+securedrop-export (0.3.0+bullseye) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 05 Jul 2022 17:37:31 -0400


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-export/issues/98
Towards https://github.com/freedomofpress/securedrop-debian-packages-lfs/issues/84
