### PR TITLE
Add Bullseye change log entry for SecureDrop Client 0.8.0

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.8.0+bullseye) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 06 Jul 2022 14:06:23 +1000
+
 securedrop-client (0.7.0+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
See https://github.com/freedomofpress/securedrop-client/blob/0.8.0/changelog.md