### PR TITLE
docs: README correction for changelog script invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ you must update the changelog.
 Run the following script to create a new entry that you will update with the same bullets from the package's own changelog.
 
 ```
-./scripts/update-changelog securedrop-foobar
+PKG_VERSION=x.y.z ./scripts/update-changelog securedrop-foobar
 ```
 
 Build the package:


### PR DESCRIPTION
The script requires a PKG_VERSION as well:

https://github.com/freedomofpress/securedrop-debian-packaging/blob/adf54b816c87fe53f551853d98d6056b1c107486/scripts/update-changelog#L32-L35