### PR TITLE
ci: make all nightly builds follow Debian version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,7 @@ jobs:
       - *removevirtualenv
       - *installdeps
       - *setsdviewername
-      - *setmetapackageversion
+      - *setmetapackageversionplatform
       - *builddebianpackage
 
   build-bullseye-securedrop-workstation-viewer:
@@ -575,7 +575,7 @@ jobs:
       - *removevirtualenv
       - *installdeps
       - *setsdviewername
-      - *setmetapackageversion
+      - *setmetapackageversionplatform
       - *builddebianpackage
 
   build-nightly-buster-securedrop-workstation-viewer:
@@ -586,8 +586,8 @@ jobs:
       - *removevirtualenv
       - *installdeps
       - *setsdviewername
-      - *getnightlymetapackageversion
-      - *updatedebianchangelog
+      - *getnightlymetapackageversionplatform
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -600,8 +600,8 @@ jobs:
       - *removevirtualenv
       - *installdeps
       - *setsdviewername
-      - *getnightlymetapackageversion
-      - *updatedebianchangelog
+      - *getnightlymetapackageversionplatform
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ common-steps:
         cd ~/project/$PKG_NAME/debian
         export DEBFULLNAME='Automated builds'
         export DEBEMAIL=securedrop@freedom.press
-        dch --changelog changelog-${VERSION_CODENAME} --distribution unstable --package "$PKG_NAME" --newversion $VERSION_TO_BUILD+buster "This is an automated build."
+        dch --changelog changelog-${VERSION_CODENAME} --distribution unstable --package "$PKG_NAME" --newversion ${VERSION_TO_BUILD}+${VERSION_CODENAME} "This is an automated build."
 
 
   - &builddebianpackage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,18 +46,6 @@ common-steps:
         ./update_version.sh $VERSION_TO_BUILD
         git tag $VERSION_TO_BUILD
 
-  - &getnightlymetapackageversion
-    run:
-      name: Create nightly version for metapackages
-      command: |
-        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ~/project/${PKG_NAME}/debian/changelog-buster | head -n1)
-        # Nightly versioning format is: LATEST_TAG-dev-YYMMDD-HHMMSS
-        export VERSION_TO_BUILD="$CURRENT_VERSION-dev-$(date +%Y%m%d)-$(date +%H%M%S)"
-        # Enable access to this env var in subsequent run steps
-        echo $VERSION_TO_BUILD > ~/packaging/sd_version
-        echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
-
-  # TODO: remove duplication between this and above
   - &getnightlymetapackageversionplatform
     run:
       name: Create nightly version for metapackages based on platform changelog
@@ -125,16 +113,6 @@ common-steps:
         echo $PKG_NAME > ~/packaging/sd_package_name
         echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
 
-  - &updatedebianchangelog
-    run:
-      name: Update debian changelog
-      command: |
-        cd ~/project/$PKG_NAME/debian
-        export DEBFULLNAME='Automated builds'
-        export DEBEMAIL=securedrop@freedom.press
-        dch --changelog changelog-buster --distribution unstable --package "$PKG_NAME" --newversion $VERSION_TO_BUILD+buster "This is an automated build."
-
-  # TODO: Remove duplication with above
   - &updatedebianchangelogplatform
     run:
       name: Update debian changelog based on platform changelog
@@ -201,17 +179,6 @@ common-steps:
         echo $PKG_NAME > ~/packaging/sd_package_name
         echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
 
-  - &setmetapackageversion
-    run:
-      name: Get metapackage version via distribution changelog
-      command: |
-        CURRENT_VERSION=$(grep -oP "\d+\.\d+\.\d+" ${PKG_NAME}/debian/changelog-buster | head -n1)
-        export VERSION_TO_BUILD="$CURRENT_VERSION"
-        # Enable access to this env var in subsequent run steps
-        echo $VERSION_TO_BUILD > ~/packaging/sd_version
-        echo 'export VERSION_TO_BUILD=$(cat ~/packaging/sd_version)' >> $BASH_ENV
-
-  # TODO: remove duplication between this and above
   - &setmetapackageversionplatform
     run:
       name: Get metapackage version via changelog for the current platform
@@ -376,7 +343,7 @@ jobs:
       - *installdeps
       - *clonesecuredroplog
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -401,7 +368,7 @@ jobs:
       - *installdeps
       - *clonesecuredroplog
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -426,7 +393,7 @@ jobs:
       - *installdeps
       - *clonesecuredropclient
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -451,7 +418,7 @@ jobs:
       - *installdeps
       - *clonesecuredropclient
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -476,7 +443,7 @@ jobs:
       - *installdeps
       - *clonesecuredropproxy
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -501,7 +468,7 @@ jobs:
       - *installdeps
       - *clonesecuredropproxy
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -526,7 +493,7 @@ jobs:
       - *installdeps
       - *clonesecuredropexport
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -551,7 +518,7 @@ jobs:
       - *installdeps
       - *clonesecuredropexport
       - *getnightlyversion
-      - *updatedebianchangelog
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -633,7 +600,7 @@ jobs:
       - checkout
       - *installdeps
       - *setsdconfigname
-      - *setmetapackageversion
+      - *setmetapackageversionplatform
       - *builddebianpackage
 
   build-bullseye-securedrop-workstation-config:
@@ -643,7 +610,7 @@ jobs:
       - checkout
       - *installdeps
       - *setsdconfigname
-      - *setmetapackageversion
+      - *setmetapackageversionplatform
       - *builddebianpackage
 
   build-nightly-bullseye-securedrop-workstation-config:
@@ -653,8 +620,8 @@ jobs:
       - checkout
       - *installdeps
       - *setsdconfigname
-      - *getnightlymetapackageversion
-      - *updatedebianchangelog
+      - *getnightlymetapackageversionplatform
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -666,7 +633,7 @@ jobs:
       - checkout
       - *installdeps
       - *setsdkeyringname
-      - *setmetapackageversion
+      - *setmetapackageversionplatform
       - *builddebianpackage
 
   build-bullseye-securedrop-keyring:
@@ -676,7 +643,7 @@ jobs:
       - checkout
       - *installdeps
       - *setsdkeyringname
-      - *setmetapackageversion
+      - *setmetapackageversionplatform
       - *builddebianpackage
 
   build-nightly-buster-securedrop-keyring:
@@ -686,8 +653,8 @@ jobs:
       - checkout
       - *installdeps
       - *setsdkeyringname
-      - *getnightlymetapackageversion
-      - *updatedebianchangelog
+      - *getnightlymetapackageversionplatform
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs
@@ -699,8 +666,8 @@ jobs:
       - checkout
       - *installdeps
       - *setsdkeyringname
-      - *getnightlymetapackageversion
-      - *updatedebianchangelog
+      - *getnightlymetapackageversionplatform
+      - *updatedebianchangelogplatform
       - *builddebianpackage
       - *addsshkeys
       - *commitworkstationdebs

--- a/securedrop-client/debian/changelog-bullseye
+++ b/securedrop-client/debian/changelog-bullseye
@@ -1,0 +1,176 @@
+securedrop-client (0.8.0+bullseye) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 06 Jul 2022 14:06:23 +1000
+
+securedrop-client (0.7.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 20 Apr 2022 10:41:31 -0400
+
+securedrop-client (0.6.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 15 Feb 2022 10:45:20 -0800
+
+securedrop-client (0.5.1+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 02 Dec 2021 16:41:49 -0800
+
+securedrop-client (0.5.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 01 Dec 2021 12:09:27 -0800
+
+securedrop-client (0.4.1+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 17 Mar 2021 11:20:12 -0700
+
+securedrop-client (0.4.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 10 Dec 2020 14:36:06 -0800
+
+securedrop-client (0.3.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+ 
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Nov 2020 11:40:46 -0500
+
+securedrop-client (0.2.1+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 16 Jul 2020 11:56:07 -0400
+
+securedrop-client (0.2.0+buster) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 29 May 2020 17:19:31 -0400
+
+securedrop-client (0.1.6+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 31 Mar 2020 10:45:27 -0400
+
+securedrop-client (0.1.5+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 30 Mar 2020 14:11:21 -0400
+
+securedrop-client (0.1.4+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 26 Mar 2020 11:45:01 -0400
+
+securedrop-client (0.1.3+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- mickael e. <mickael@freedom.press>  Wed, 18 Mar 2020 12:32:35 -0400
+
+securedrop-client (0.1.2+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- redshiftzero <jen@freedom.press>  Tue, 10 Mar 2020 13:12:54 -0400
+
+securedrop-client (0.1.1+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- redshiftzero <jen@freedom.press>  Tue, 03 Mar 2020 11:39:03 -0500
+
+securedrop-client (0.1.0+buster) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- redshiftzero <jen@freedom.press>  Fri, 21 Feb 2020 13:34:42 -0500
+
+securedrop-client (0.0.13+buster) unstable; urgency=medium
+
+  * remove user refresh and replace with sync icon (#732)
+  * build-requirements: update for production beta (#730)
+  * No sync on ui operations (#721)
+  * Use SecureQLabel for message previews (#720)
+  * Show DD MMM format for source title (#719)
+  * Add new metadata queue. (#715)
+  * Improve performance of storage.get_remote_data (#709)
+  * app/queue: prioritize user-triggered state changes (#708)
+  * Fix HTML entities being escaped in speech bubbles. (#703)
+  * Activity indicator for file download / decryption. (#702)
+  * Rename VMs (#701)
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 17 Jan 2020 18:20:20 -0800
+
+securedrop-client (0.0.12+buster) unstable; urgency=medium
+
+  * Use revised VM names (securedrop-workstation #285)
+  * Delete sources using the general queue (#402)
+  * Add a preview snippet for sources (#135)
+  * Add a show/hide password feature on the login screen (#659)
+  * Disable sync icon during active sync (#388)
+  * Add keyboard shortcuts for sending replies (#606)
+  * Add hover states for UI elements (#591)
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 17 Jan 2020 18:20:20 -0800
+
+securedrop-client (0.0.11+buster) unstable; urgency=medium
+
+  * Add apparmor profile (#673)
+  * Add failure message for replies (#664)
+  * Move metadata sync to api queue (#640)
+  * Add print integration (#631)
+  * Populate source list immediately upon login (#626)
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 19 Dec 2019 12:20:20 -0500
+
+securedrop-client (0.0.10+buster) unstable; urgency=medium
+
+  * Add Python 3.7/buster support (#568, #609)
+  * Add export to USB support (#611, #547, #562, #563, #564)
+  * Retry failed replies (#530)
+  * Pause queue on auth errors, connection failures, and timeouts (#531)
+  * Add pending reply status, persist replies in the database (#578)
+  * Set realistic timeouts, scale file/message download timeouts using file size (#515, #567)
+  * Update qrexec keyword prefix characters (#537)
+  * Reply box no longer accepts rich text input (#580)
+  * Format reply box placeholder text (#597)
+  * Redesign FileWidget (#535)
+  * Style conversation header (#543)
+  * Login form submits if user presses Enter or Return (#615)
+  * Enable changeable log levels (#603)
+  * Remove borders around source list, send icon, and reply box (#505)
+  * Move star and date in source widget (#506)
+  * Polish source widget (#522)
+  * Polish offline UI (#586)
+  * Add branding image to left pane and polish styling (#520)
+  * Add empty conversation view (#510)
+  * Update fonts weights and colors (#502)
+  * Bugfix: handle missing files during export and open (#566)
+  * Bugfix: do not escape quotes in SecureQLabel (#516)
+  * Bugfix: skip round trip to user endpoint during logic (#605, #621, #623)
+  * Bugfix: fix bug of sources disappearing from source list (#620)
+  * Bugfix: fix db warnings upon source deletion (#581)
+  * Add more detailed developer documentation (#508)
+  * Add documentation for updating dependencies (#536)
+  * Ensure build/dev requirements files stay in sync (#602)
+  * Parallelize test suite (#569)
+  * Ignore third-party deprecation warnings (#576)
+  * Add bandit to check target (#548)
+
+ -- redshiftzero <jen@freedom.press>  Wed, 20 Nov 2019 09:20:22 -0500
+

--- a/securedrop-keyring/debian/changelog-bullseye
+++ b/securedrop-keyring/debian/changelog-bullseye
@@ -1,0 +1,17 @@
+securedrop-keyring (0.1.6+buster) unstable; urgency=medium
+
+  * Update public key with new expiration date 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 17 May 2022 14:06:56 -0700
+
+securedrop-keyring (0.1.5+buster) unstable; urgency=medium
+
+  * Added new public key to support planned signing key rotation
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 25 May 2021 10:44:05 -0400
+
+securedrop-keyring (0.1.4+buster) unstable; urgency=medium
+
+  * Initial release for securedrop workstation
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 22 May 2020 11:18:05 -0400

--- a/securedrop-workstation-config/debian/changelog-bullseye
+++ b/securedrop-workstation-config/debian/changelog-bullseye
@@ -1,0 +1,59 @@
+securedrop-workstation-config (0.2.0+buster) unstable; urgency=medium
+
+  * Update mimeapps.list.sd-viewer to work on Bullseye (Qubes 4.1) 
+ 
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 29 Jun 2022 15:25:05 -0700
+
+securedrop-workstation-config (0.1.7+buster) unstable; urgency=medium
+
+  * Add mp4 to allow-list for sd-viewer
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 02 May 2022 16:05:46 -0700
+
+securedrop-workstation-config (0.1.6+buster) unstable; urgency=medium
+
+  * Bugfix in .desktop file syntax; improved Fail Closed behavior
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 02 Mar 2021 15:00:00 -0400
+
+securedrop-workstation-config (0.1.5+buster) unstable; urgency=medium
+
+  * Adds a "default" mimetype handler, for reuse by other VMs
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 01 Oct 2020 17:55:53 -0700
+
+securedrop-workstation-config (0.1.4+buster) unstable; urgency=medium
+
+  * Provides mime type files all VMs for template consolidation
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 26 Aug 2020 15:24:29 -0400
+
+securedrop-workstation-config (0.1.3+buster) unstable; urgency=medium
+
+  * Adds securedrop-keyring to list of dependencies
+
+ -- SecureDrop Team <securedrop@freedom.press>  Fri, 22 May 2020 12:02:57 -0400
+
+securedrop-workstation-config (0.1.2+buster) unstable; urgency=medium
+
+  * Bump securedrop-workstation-config to 0.1.2
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 10 Feb 2020 17:45:01 -0500
+
+securedrop-workstation-config (0.1.1+buster) unstable; urgency=medium
+
+  * Remove libgnomevfs2-bin from dependencies and bump to 0.1.1
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 14:56:04 -0400
+
+securedrop-workstation-config (0.1.0+buster) unstable; urgency=medium
+
+  * Provides buster support through buster-specific package.
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 31 Oct 2019 12:22:23 -0400
+
+securedrop-workstation-config (0.1.0) unstable; urgency=medium
+
+  * Initial release.
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 4 Oct 2018 15:33:10 -0400


### PR DESCRIPTION
Fixes #362 by making all nightly builds consistently follow the Debian version they target, in particular the failing `securedrop-workstation-viewer` build.

This pull request is intended as a compromise between (a) our [current state](https://github.com/freedomofpress/securedrop-debian-packaging/issues/362#issuecomment-1183746608), in which some packages have nightlies built separately for Debian bullseye versus buster, and (b) our [desired state](https://github.com/freedomofpress/securedrop-debian-packaging/issues/362#issuecomment-1183693946), in which all packages are built according to a single versioning and changelog stream.

If we don't actually want this compromise, we can close this pull request in favor of consolidating changelogs and CI steps per <https://github.com/freedomofpress/securedrop-debian-packaging/issues/362#issuecomment-1183693946>.


## Checklist

- [ ] Changes look sensible on visual review.
- [ ] Branch-level CI passes on this branch.
- [ ] Nightly CI passes on `please-build-nightlies` with the head of this branch plus df682c52315489ceac885c081fb731f8a3c9575f.