### PR TITLE
chore: merge bullseye changelogs into "buster" changelog

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,4 +1,4 @@
-securedrop-client (0.8.0+bullseye) unstable; urgency=medium
+securedrop-client (0.8.0+buster) unstable; urgency=medium
 
   * See changelog.md 
 

--- a/securedrop-export/debian/changelog-bullseye
+++ b/securedrop-export/debian/changelog-bullseye
@@ -1,5 +1,0 @@
-securedrop-export (0.3.0+bullseye) unstable; urgency=medium
-
-  * See changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Tue, 05 Jul 2022 17:37:31 -0400

--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-export (0.3.0+bullseye) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 05 Jul 2022 17:37:31 -0400
+
 securedrop-export (0.2.6+buster) unstable; urgency=medium
 
   * See changelog.md

--- a/securedrop-export/debian/changelog-buster
+++ b/securedrop-export/debian/changelog-buster
@@ -1,4 +1,4 @@
-securedrop-export (0.3.0+bullseye) unstable; urgency=medium
+securedrop-export (0.3.0+buster) unstable; urgency=medium
 
   * See changelog.md
 

--- a/securedrop-log/debian/changelog-bullseye
+++ b/securedrop-log/debian/changelog-bullseye
@@ -1,5 +1,0 @@
-securedrop-log (0.2.0+bullseye) unstable; urgency=medium
-
-  * See changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 21:51:55 -0400

--- a/securedrop-log/debian/changelog-buster
+++ b/securedrop-log/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-log (0.2.0+bullseye) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 21:51:55 -0400
+
 securedrop-log (0.1.2+buster) unstable; urgency=medium
 
   * see changelog.md 

--- a/securedrop-log/debian/changelog-buster
+++ b/securedrop-log/debian/changelog-buster
@@ -1,4 +1,4 @@
-securedrop-log (0.2.0+bullseye) unstable; urgency=medium
+securedrop-log (0.2.0+buster) unstable; urgency=medium
 
   * See changelog.md
 

--- a/securedrop-proxy/debian/changelog-bullseye
+++ b/securedrop-proxy/debian/changelog-bullseye
@@ -1,5 +1,0 @@
-securedrop-proxy (0.4.0+bullseye) unstable; urgency=medium
-
-  * See changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 21:44:26 -0400

--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,4 +1,4 @@
-securedrop-proxy (0.4.0+bullseye) unstable; urgency=medium
+securedrop-proxy (0.4.0+buster) unstable; urgency=medium
 
   * See changelog.md
 

--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-proxy (0.4.0+bullseye) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 21:44:26 -0400
+
 securedrop-proxy (0.3.1+buster) unstable; urgency=medium
  
   * See changelog.md

--- a/securedrop-workstation-viewer/debian/changelog-bullseye
+++ b/securedrop-workstation-viewer/debian/changelog-bullseye
@@ -1,5 +1,0 @@
-securedrop-workstation-viewer (0.2.0+bullseye) unstable; urgency=medium
-
-  * Move packages to debhelper-compat 11
-
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 22:03:18 -0400

--- a/securedrop-workstation-viewer/debian/changelog-buster
+++ b/securedrop-workstation-viewer/debian/changelog-buster
@@ -1,4 +1,4 @@
-securedrop-workstation-viewer (0.2.0+bullseye) unstable; urgency=medium
+securedrop-workstation-viewer (0.2.0+buster) unstable; urgency=medium
 
   * Move packages to debhelper-compat 11
 

--- a/securedrop-workstation-viewer/debian/changelog-buster
+++ b/securedrop-workstation-viewer/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-workstation-viewer (0.2.0+bullseye) unstable; urgency=medium
+
+  * Move packages to debhelper-compat 11
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 04 Jul 2022 22:03:18 -0400
+
 securedrop-workstation-viewer (0.1.1+buster) unstable; urgency=medium
 
   * Fixes typo in control fields, replaces package


### PR DESCRIPTION
Closes #362 by merging `changelog-bullseye` entries into `changelog-buster`, so that all non-kernel (`securedrop-workstationg-grsec`) nightly jobs jobs read and update a single changelog file.

Per <https://github.com/freedomofpress/securedrop-debian-packaging/issues/362#issuecomment-1190784465>, `changelog-buster` will eventually become the canonical `changelog` file.


## Checklist

- [x] Changes look sensible on visual review.
- [x] Branch-level CI passes on this branch.
- [ ] Nightly CI passes on `please-build-nightlies` with the head of this branch plus c4622d050fe6640de665ae134a278ec632bacfbf.
    - [ ] In particular, `securedrop-workstation-viewer` is successfully built and [published](https://apt-test.freedom.press/pool/nightlies/s/securedrop-workstation-viewer/) for both buster and bullseye.