### PR TITLE
Update release key fingerprint in securedrop-keyring preinst check

### DIFF
--- a/securedrop-keyring/debian/preinst
+++ b/securedrop-keyring/debian/preinst
@@ -4,10 +4,11 @@ set -e
 
 # Solution adapted from DKG's work on `deb.torproject.org-keyring` and
 # the securedrop core keyring package.
-# In SecureDrop Workstation versions before 0.3.0, the salt provisioning
-# logic uses pkgrepo.managed, which writes the key to `/etc/apt/trusted.gpg`.
-# It's cleaner to use the trusted.gpg.d subdirectory, since we can
-# update that trivially in future versions of the keyring package.
+#
+# The salt provisioning logic uses pkgrepo.managed, which writes the
+# key to `/etc/apt/trusted.gpg`. It's cleaner to use the trusted.gpg.d
+# subdirectory, since we can update that trivially in future versions
+# of the keyring package.
 #
 # Therefore let's clean up prior versions of the key installed
 # to the general apt keyring, to ensure we only have one signing key
@@ -20,11 +21,11 @@ if [ -e /etc/apt/trusted.gpg ] && which gpg >/dev/null; then
 
    if gpg --homedir="$h" \
           --batch --no-tty --no-default-keyring --keyring /etc/apt/trusted.gpg \
-          --list-key 0x22245C81E3BAEB4138B36061310F561200F4AD77 > /dev/null 2>&1 ; then
+          --list-key 0x2359E6538C0613E652955E6C188EDD3B7B22E6A3 > /dev/null 2>&1 ; then
       gpg --homedir="$h" \
           --batch --no-tty --no-default-keyring --keyring /etc/apt/trusted.gpg \
           --no-auto-check-trustdb \
-          --delete-key 0x22245C81E3BAEB4138B36061310F561200F4AD77 || true
+          --delete-key 0x2359E6538C0613E652955E6C188EDD3B7B22E6A3 || true
    fi
    )
 fi


### PR DESCRIPTION
Updates the key removal code in the `preinst` check in the `securedrop-keyring` package.

This `preinst` check removes any redundant copies of the key from `/etc/apt/trusted.gpg` (they keyring package itself places the key in `/etc/apt/trusted.gpg.d/`). However, because it is looking for an outdated fingerprint, it won't find it even if it exists.

Resolves #367 

## Testing

On a machine that is configured as `prod`, or that was re-provisioned from `prod` to `dev` without an uninstall in between, you should be able to find evidence that the production signing public key exists in `/etc/apt/trusted.gpg`, by running the following commands in `sd-app`:

```bash
mkdir /tmp/tempkey
gpg --homedir="/tmp/tempkey" --no-default-keyring --keyring /etc/apt/trusted.gpg --list-keys
```

It's expected to find the `TESTING` key there, but if the production key shows up there (`2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3`), that's the regression that this PR is expected to resolve. 

If you're able to reproduce that issue, build a new `securedrop-keyring` package (e.g., 1. update changelog with new version, 2. build new version with `PKG_VERSION=foo make securedrop-keyring`, 3. shuttle into `sd-app` by way of `dom0`) and install it in `sd-app`. If the revised `preinst` code runs successfully, you'll be able to confirm this:

- [ ] Repeat the `gpg` command above and verify that you no longer see the production signing key.