### PR TITLE
Add pull request templates for common tasks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/changelog_update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/changelog_update.md
@@ -1,0 +1,9 @@
+---
+name: Change log update
+about: Prepare the release of a Debian package.
+
+---
+
+## Description
+
+_Which package are you releasing? Please link to to **release tracking issue**._

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,17 @@
+---
+name: Default
+about: For all the cases that don't have a specific template.
+
+---
+
+## Description
+
+_What is the PR doing, and why?_
+
+## Test plan
+
+- Automated tests ([Circle CI][ci]):
+  - [ ] All Bullseye jobs are passing
+  - Bookworm failures are not ignored:
+    - [ ] This PR does not introduce any new Bookworm failures
+    - [ ] An issue is open for all new Bookworm failures

--- a/.github/PULL_REQUEST_TEMPLATE/package_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/package_addition.md
@@ -1,0 +1,22 @@
+---
+name: Package addition
+about: Add or upgrade a dependency for one of our Debian packages.
+
+---
+
+## Description
+
+_Which packages are you adding, and why?_
+
+## Test plan
+
+- Automated tests ([Circle CI][ci]):
+  - [ ] All Bullseye jobs are passing
+  - [ ] Bookworm failures are not ignored:
+    - This PR does not introduce any new Bookworm failures
+    - An issue is open for all new Bookworm failures
+- Security:
+  - [ ] A [diff review][review-docs] was performed for all build dependencies
+
+  [ci]: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-debian-packaging
+  [review-docs]: https://github.com/freedomofpress/securedrop/wiki/Dependency-specification-and-update-policies

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-## Checklist
-
-* [ ] `bullseye` builds and jobs are passing
-* [ ] This PR does not introduce any new `bookworm` test failures
-* [ ] If there are `bookworm` test failures, an issue has been filed for them


### PR DESCRIPTION
This is primarily aimed at preventing us from missing any dependency review in the future.

1. Adds an item to remind that diff reviews must be performed when adding packages
2. Adds a template for change log updates, which are relatively frequent
3. Moves the default template, and rewords it slightly to match the other

Prompted by: #379 