### PR TITLE
Fix a few breaking changes in scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+scripts/__pycache__/
 tests/__pycache__/
 debhelper-build-stamp
 *.debhelper.log

--- a/scripts/build-sync-wheels
+++ b/scripts/build-sync-wheels
@@ -7,6 +7,9 @@ import subprocess
 import tempfile
 import shutil
 import argparse
+from pathlib import Path
+
+import utils
 
 
 if os.geteuid() == 0:
@@ -36,13 +39,12 @@ def main():
     if "PKG_DIR" in os.environ and \
             not any(arg.startswith("--pkg-dir") for arg in sys.argv):
         sys.argv.extend(["--pkg-dir", os.environ["PKG_DIR"]])
-        sys.argv.extend(["--project", os.path.basename(os.environ["PKG_DIR"])])
 
     parser = argparse.ArgumentParser(
         description="Builds and stores sources and wheels"
     )
     parser.add_argument("--pkg-dir", help="Package directory", required=True)
-    parser.add_argument("--project", help="Project name to update", required=True)
+    parser.add_argument("--project", help="Project name to update")
     parser.add_argument(
         "--clobber", action="store_true", default=False,
         help="Whether to overwrite wheels and source tarballs",
@@ -60,13 +62,18 @@ def main():
         subprocess.check_call(cmd)
         args.pkg_dir = git_clone_directory
     else:
+        args.pkg_dir = os.path.expanduser(args.pkg_dir)
         git_clone_directory = ""
         if not os.path.exists(args.pkg_dir):
             print(f"Project directory missing {args.pkg_dir}.")
             sys.exit(1)
 
     req_path = os.path.join(args.pkg_dir, args.requirements, "requirements.txt")
-    local_wheels = os.path.join(args.project, "wheels")
+    if args.project is not None:
+        project_name = args.project
+    else:
+        project_name = utils.project_name(Path(args.pkg_dir))
+    local_wheels = os.path.join(project_name, "wheels")
 
     if not os.path.exists(req_path):
         print("requirements.txt missing at {0}.".format(req_path))

--- a/scripts/update-requirements
+++ b/scripts/update-requirements
@@ -9,16 +9,17 @@ import subprocess
 from pathlib import Path
 from typing import List
 
+import utils
+
 
 def parse_args():
     # For backwards-compat
     if "PKG_DIR" in os.environ and \
             not any(arg.startswith("--pkg-dir") for arg in sys.argv):
         sys.argv.extend(["--pkg-dir", os.environ["PKG_DIR"]])
-        sys.argv.extend(["--project", os.path.basename(os.environ["PKG_DIR"])])
     parser = argparse.ArgumentParser(description="Update requirements files with sha256sums from our wheels")
     parser.add_argument("--pkg-dir", help="Package directory", required=True)
-    parser.add_argument("--project", help="Project to update", required=True)
+    parser.add_argument("--project", help="Project to update")
     parser.add_argument("--requirements", help="Directory that contains requirements.txt inside the package directory",
                         default="requirements")
     return parser.parse_args()
@@ -26,9 +27,13 @@ def parse_args():
 
 def main():
     args = parse_args()
-    pkg_dir = Path(args.pkg_dir)
+    pkg_dir = Path(args.pkg_dir).expanduser()
+    if args.project is not None:
+        project_name = args.project
+    else:
+        project_name = utils.project_name(pkg_dir)
     requirements_file = pkg_dir / args.requirements / "requirements.txt"
-    project = Path(__file__).parent.parent / args.project
+    project = Path(__file__).parent.parent / project_name
 
     # First remove index line and any PyQt or sip dependency
     cleaned_lines = cleanup(requirements_file)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,20 @@
+"""
+Shared functions between various scripts
+"""
+import re
+from pathlib import Path
+
+RE_NAME = re.compile(r'name="(.*?)"')
+
+
+def project_name(path: Path) -> str:
+    """Extract the project name from setup.py"""
+    setup_py = path / "setup.py"
+    if not setup_py.exists():
+        raise RuntimeError(f"No setup.py in {path}."
+                           "If this isn't a Python project, use --project?")
+    search = RE_NAME.search(setup_py.read_text())
+    if not search:
+        raise RuntimeError(f"Unable to parse name out of {setup_py}. "
+                           "If this isn't a Python project, use --project?")
+    return search.group(1)

--- a/tests/test_update_requirements.py
+++ b/tests/test_update_requirements.py
@@ -1,5 +1,6 @@
 import imp
 import os
+import sys
 import pytest
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from pathlib import Path
 path_to_script = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "../scripts/update-requirements"
 )
+sys.path.append(os.path.dirname(path_to_script))
 update_requirements = imp.load_source("update-requirements", path_to_script)
 
 TEST_SOURCE_HASH = "8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83"


### PR DESCRIPTION
* Make sure we call `os.path.expanduser()` on `pkg_dir`
* Try to guess project from `setup.py` instead of expecting it to be cloned in a specific way (that breaks in CI).

Closes https://github.com/freedomofpress/securedrop-client/pull/1572

## Testing
* Rename your `securedrop-client` folder to something else, I did `securedrop-test`.
* from this repo, run `PKG_DIR=~/github/freedomofpress/securedrop-test make requirements`, with a tilde specifically, and make sure it works properly.