### PR TITLE
Have `build-sync-wheels` error if not in a virtualenv

### DIFF
--- a/scripts/build-sync-wheels
+++ b/scripts/build-sync-wheels
@@ -16,6 +16,13 @@ if os.geteuid() == 0:
     # tar has issues when resetting permissions and ends up
     # causing very subtle reproducibility issues.
     print("This script cannot be run as root.", file=sys.stderr)
+    # sys.exit(1)
+if "VIRTUAL_ENV" not in os.environ:
+    print(
+        "This script should be run in a virtualenv: "
+        "`source .venv/bin/activate`",
+        file=sys.stderr
+    )
     sys.exit(1)
 
 # Set SOURCE_DATE_EPOCH to a predictable value. Using the first


### PR DESCRIPTION
Otherwise you get a super obscure error about `build.__main__` being a package that can't be directly executed.

Fixes #388.

## Test plan
In a container/VM, run `make install-deps` and don't activate the venv. Make sure you're a non-root user.
* [ ] Run `./scripts/build-sync-wheels`, get an error message that you're not using the venv.
* [ ] Follow the prompt to activate the venv. Run `./scripts/build-sync-wheels`, you should now get an error that --pkg-dir is required.